### PR TITLE
ci: download pjrt cpu plugin in pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -34,16 +34,13 @@ jobs:
           extra-repositories: https://r-xla.r-universe.dev
           use-public-rspm: true
 
-
-      - name: PJRT CPU Plugin
-        run: Rscript -e "pjrt::pjrt_plugin('cpu')"
-
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown
           needs: website
           cache: false
+      - name: PJRT CPU Plugin
+        run: Rscript -e "pjrt::pjrt_plugin('cpu')"
 
       - name: Install package
         run: R CMD INSTALL .


### PR DESCRIPTION
Solves #82 so examples are shown properly on the package website