### PR TITLE
fix: backward pass now operates on `GraphBox` object

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -277,13 +277,8 @@ maybe_box_tensorish <- function(x) {
     }
     gval <- x$gnode
     get_box_or_register_const(current_desc, gval)
-  } else if (is_anvil_tensor(x) || test_scalar(x)) {
+  } else if (is_anvil_tensor(x) || is_lit(x)) {
     get_box_or_register_const(current_desc, x)
-  } else if (is_graph_node(x)) {
-    # FIXME: !!!
-    # We use this in gradient, where we pass gvals to the backward rules
-    # but I think we should handle this differently
-    GraphBox(x, current_desc)
   } else if (is_debug_box(x)) {
     # We want debug mode to emulate standard tracing, so each primitive initializes it's own
     # GraphDescriptor during debug mode and we evaluate with GraphBox objects
@@ -292,7 +287,7 @@ maybe_box_tensorish <- function(x) {
   } else if (is_abstract_tensor(x)) {
     cli_abort("Don't use AbtractTensors as inputs; For debugging, use `debug_box()`")
   } else {
-    x
+    cli_abort("Expected tensorish value, but got {.cls {class(x)[1]}}")
   }
 }
 
@@ -474,7 +469,7 @@ init_desc_from_graph <- function(desc, graph, outputs = TRUE) {
 #'   If this is `TRUE`, inputs that are `AnvilTensor`s are treated as unknown.
 #'   If this is `FALSE` (default), `AnvilTensor`s are treated as constants.
 #' @param lit_to_tensor (`logical(1)`)\cr
-#'   Whether to convert literals to `AnvilTensor`s.
+#'   Whether to convert literal inputs to `AnvilTensor`s.
 #'   Should only be used for higher-order primitives like if and while, where no static inputs are possible.
 #' @param args_flat (`list`)\cr
 #'   The flattened arguments. Also requires passing `in_tree`.

--- a/R/rules-backward.R
+++ b/R/rules-backward.R
@@ -349,7 +349,7 @@ p_convert[["backward"]] <- function(inputs, outputs, grads, dtype, ambiguous, .r
   grad <- grads[[1L]]
   # the ambiguity is determined by the input, not the `ambiguous` parameter
   list(
-    if (.required[[1L]]) nvl_convert(grad, dtype(operand), inputs[[1L]]$aval$ambiguous)
+    if (.required[[1L]]) nvl_convert(grad, dtype(operand), inputs[[1L]]$gnode$aval$ambiguous)
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -159,3 +159,7 @@ dtype_abstract <- function(x) {
 dtype2string <- function(dtype, ambiguous = FALSE) {
   paste0(repr(dtype), if (ambiguous) "?")
 }
+
+is_lit <- function(x) {
+  test_scalar(x) && (is.numeric(x) || is.logical(x))
+}


### PR DESCRIPTION
`GraphValue`s should not be passed around, that's what boxes are for.