### PR TITLE
feat: prevent tracing of already-jitted functions

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -493,6 +493,9 @@ trace_fn <- function(
   args_flat = NULL,
   in_tree = NULL
 ) {
+  if (inherits(f, "JitFunction")) {
+    cli_abort("{.arg f} must not be a jitted function.")
+  }
   if (is.null(args)) {
     if (is.null(args_flat) || is.null(in_tree)) {
       cli_abort("args or args_flat and in_tree must be provided")

--- a/R/jit.R
+++ b/R/jit.R
@@ -116,6 +116,7 @@ jit <- function(f, static = character(), cache_size = 100L, donate = character()
     call_xla(exec, out_tree, const_tensors, args_flat, is_static_flat, avals_out)
   }
   formals(f_jit) <- formals2(f)
+  class(f_jit) <- "JitFunction"
   f_jit
 }
 

--- a/tests/testthat/test-jit.R
+++ b/tests/testthat/test-jit.R
@@ -116,8 +116,14 @@ test_that("multiple returns", {
   )
 })
 
-test_that("calling jit on jit", {
-  # TODO: (Not sure what we want here)
+test_that("jitted function has class JitFunction", {
+  f_jit <- jit(function(x) x)
+  expect_s3_class(f_jit, "JitFunction")
+})
+
+test_that("calling jit on jit errors", {
+  f_jit <- jit(function(x) x)
+  expect_error(jit(f_jit)(nv_tensor(1)), "must not be a jitted function")
 })
 
 test_that("keeps argument names", {


### PR DESCRIPTION
Give jitted functions the "JitFunction" class attribute and check in trace_fn that the function to trace is not a jitted function.