### PR TITLE
BREAKING CHANGE: nv_scalar not ambiguous by default

### DIFF
--- a/R/tensor.R
+++ b/R/tensor.R
@@ -21,7 +21,7 @@
 #'   Whether the dtype should be marked as ambiguous.
 #'   For [nv_tensor()], defaults to `FALSE` (non-ambiguous) for new tensors,
 #'   or preserves the existing value when `data` is already an [`AnvilTensor`].
-#'   For [nv_scalar()], defaults to `TRUE` when `dtype` is `NULL` and data is numeric, `FALSE` otherwise.
+#'   For [nv_scalar()], defaults to `FALSE` (non-ambiguous).
 #'
 #' @return ([`AnvilTensor`]) A tensor object.
 #'
@@ -91,9 +91,8 @@ ensure_nv_tensor <- function(x, ambiguous = FALSE) {
 #' @rdname AnvilTensor
 #' @export
 nv_scalar <- function(data, dtype = NULL, device = NULL, ambiguous = NULL) {
-  # Ambiguous if dtype is not explicitly specified (and not logical)
   if (is.null(ambiguous)) {
-    ambiguous <- is.null(dtype) && !is.logical(data)
+    ambiguous <- FALSE
   }
   if (is_dtype(dtype)) {
     dtype <- as.character(dtype)

--- a/tests/testthat/test-ambiguity.R
+++ b/tests/testthat/test-ambiguity.R
@@ -1,15 +1,15 @@
-test_that("nv_scalar returns ambiguous tensor when dtype is NULL (default)", {
-  # Numeric scalars without explicit dtype should be ambiguous
+test_that("nv_scalar returns non-ambiguous tensor by default", {
+  # Numeric scalars without explicit dtype should be non-ambiguous
   x_f32 <- nv_scalar(1.0)
-  expect_true(ambiguous(x_f32))
+  expect_false(ambiguous(x_f32))
   expect_equal(dtype(x_f32), as_dtype("f32"))
 
-  # Integer scalars without explicit dtype should be ambiguous
+  # Integer scalars without explicit dtype should be non-ambiguous
   x_i32 <- nv_scalar(1L)
-  expect_true(ambiguous(x_i32))
+  expect_false(ambiguous(x_i32))
   expect_equal(dtype(x_i32), as_dtype("i32"))
 
-  # Logical scalars are never ambiguous (pred type)
+  # Logical scalars are also non-ambiguous
   x_pred <- nv_scalar(TRUE)
   expect_false(ambiguous(x_pred))
   expect_equal(dtype(x_pred), as_dtype("pred"))
@@ -42,23 +42,22 @@ test_that("JIT propagates ambiguity from inputs to outputs", {
   f <- jit(function(x, y) x + y)
 
   # Both inputs ambiguous -> output should be ambiguous
-  x_amb <- nv_scalar(1.0) # ambiguous
-
-  y_amb <- nv_scalar(2.0) # ambiguous
+  x_amb <- nv_scalar(1.0, ambiguous = TRUE)
+  y_amb <- nv_scalar(2.0, ambiguous = TRUE)
   result_amb <- f(x_amb, y_amb)
   expect_true(ambiguous(result_amb))
-  expect_equal(result_amb, nv_scalar(3.0))
+  expect_equal(result_amb, nv_scalar(3.0, ambiguous = TRUE))
 
   # One input non-ambiguous -> output should be non-ambiguous
-  x_nonamb <- nv_scalar(1.0, dtype = "f32") # non-ambiguous
-  y_amb2 <- nv_scalar(2.0) # ambiguous
+  x_nonamb <- nv_scalar(1.0, dtype = "f32")
+  y_amb2 <- nv_scalar(2.0, ambiguous = TRUE)
   result_mixed <- f(x_nonamb, y_amb2)
   expect_false(ambiguous(result_mixed))
   expect_equal(result_mixed, nv_scalar(3.0, dtype = "f32"))
 
   # Both inputs non-ambiguous -> output should be non-ambiguous
-  x_nonamb2 <- nv_scalar(1.0, dtype = "f32") # non-ambiguous
-  y_nonamb <- nv_scalar(2.0, dtype = "f32") # non-ambiguous
+  x_nonamb2 <- nv_scalar(1.0, dtype = "f32")
+  y_nonamb <- nv_scalar(2.0, dtype = "f32")
   result_nonamb <- f(x_nonamb2, y_nonamb)
   expect_false(ambiguous(result_nonamb))
   expect_equal(result_nonamb, nv_scalar(3.0, dtype = "f32"))
@@ -68,10 +67,10 @@ test_that("JIT preserves ambiguity through unary operations", {
   f <- jit(function(x) -x)
 
   # Ambiguous input -> ambiguous output
-  x_amb <- nv_scalar(1.0)
+  x_amb <- nv_scalar(1.0, ambiguous = TRUE)
   result_amb <- f(x_amb)
   expect_true(ambiguous(result_amb))
-  expect_equal(result_amb, nv_scalar(-1.0))
+  expect_equal(result_amb, nv_scalar(-1.0, ambiguous = TRUE))
 
   # Non-ambiguous input -> non-ambiguous output
   x_nonamb <- nv_scalar(1.0, dtype = "f32")
@@ -81,25 +80,25 @@ test_that("JIT preserves ambiguity through unary operations", {
 })
 
 test_that("JIT handles constants with ambiguity", {
-  # Constant created with ambiguous nv_scalar
+  # Constant created with non-ambiguous nv_scalar (new default)
   f <- jit(function(x) x + nv_scalar(10))
 
-  x_amb <- nv_scalar(1.0)
+  x_amb <- nv_scalar(1.0, ambiguous = TRUE)
   result <- f(x_amb)
-  # Both input and constant are ambiguous, so output is ambiguous
-  expect_true(ambiguous(result))
+  # Input is ambiguous, constant is non-ambiguous -> non-ambiguous
+  expect_false(ambiguous(result))
   expect_equal(result, nv_scalar(11.0))
 
-  # Non-ambiguous input with ambiguous constant
+  # Non-ambiguous input with non-ambiguous constant
   x_nonamb <- nv_scalar(1.0, dtype = "f32")
   result2 <- f(x_nonamb)
-  # Mixed: one non-ambiguous, one ambiguous -> non-ambiguous
+  # Both non-ambiguous -> non-ambiguous
   expect_false(ambiguous(result2))
   expect_equal(result2, nv_scalar(11.0, dtype = "f32"))
 })
 
 test_that("format.AnvilTensor shows ambiguity with ?", {
-  x_amb <- nv_scalar(1.0)
+  x_amb <- nv_scalar(1.0, ambiguous = TRUE)
   expect_match(format(x_amb), "f32\\?")
 
   x_nonamb <- nv_scalar(1.0, dtype = "f32")
@@ -108,7 +107,7 @@ test_that("format.AnvilTensor shows ambiguity with ?", {
 
 test_that("ambiguous() generic works for AnvilTensor and AbstractTensor", {
   # AnvilTensor
-  x_anvil_amb <- nv_scalar(1.0)
+  x_anvil_amb <- nv_scalar(1.0, ambiguous = TRUE)
   expect_true(ambiguous(x_anvil_amb))
 
   x_anvil_nonamb <- nv_tensor(1.0)

--- a/tests/testthat/test-jit.R
+++ b/tests/testthat/test-jit.R
@@ -248,7 +248,7 @@ test_that("good error message when passing AbstractTensors", {
 
 test_that("jit: respects device argument", {
   f <- jit(function() 1, device = "cpu")
-  expect_equal(f(), nv_scalar(1, device = "cpu"))
+  expect_equal(f(), nv_scalar(1, device = "cpu", ambiguous = TRUE))
 })
 
 test_that("literals are not converted to scalar tensors", {

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -232,7 +232,7 @@ test_that("p_broadcast_in_dim", {
   f <- jit(nvl_broadcast_in_dim, static = c("shape", "broadcast_dimensions"))
   expect_equal(
     f(nv_scalar(1L), c(1, 2), integer()),
-    nv_tensor(1L, shape = c(1, 2), ambiguous = TRUE),
+    nv_tensor(1L, shape = c(1, 2)),
     tolerance = 1e-5
   )
 })
@@ -320,7 +320,7 @@ describe("p_if", {
   })
 
   it("works with literals as predicate", {
-    expect_equal(jit_eval(nv_if(TRUE, 1, 2)), nv_scalar(1))
+    expect_equal(jit_eval(nv_if(TRUE, 1, 2)), nv_scalar(1, ambiguous = TRUE))
   })
 })
 

--- a/tests/testthat/test-serialize.R
+++ b/tests/testthat/test-serialize.R
@@ -20,7 +20,7 @@ test_that("nv_write and nv_read works for a single tensor", {
 
 test_that("serialization preserves ambiguity", {
   # Create tensors with different ambiguity
-  ambiguous_tensor <- nv_scalar(1.0) # ambiguous
+  ambiguous_tensor <- nv_scalar(1.0, ambiguous = TRUE) # ambiguous
   non_ambiguous_tensor <- nv_tensor(1.0, dtype = "f32") # non-ambiguous
 
   lst <- list(

--- a/tests/testthat/test-tensor.R
+++ b/tests/testthat/test-tensor.R
@@ -115,7 +115,7 @@ test_that("to_abstract", {
 
   # pure
   x <- nv_scalar(1)
-  expect_equal(to_abstract(x, pure = TRUE), AbstractTensor("f32", c(), TRUE))
+  expect_equal(to_abstract(x, pure = TRUE), AbstractTensor("f32", c(), FALSE))
   expect_error(to_abstract(list(1, 2)), "is not a tensor-like object")
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -156,9 +156,9 @@ describe("gather_clamp_indices", {
 })
 
 test_that("ambiguous_abstract", {
-  # Ambiguous scalar (no explicit dtype)
-  expect_true(ambiguous_abstract(nv_scalar(1.0)))
-  expect_true(ambiguous_abstract(nv_scalar(1L)))
+  # Non-ambiguous scalar (no explicit dtype)
+  expect_false(ambiguous_abstract(nv_scalar(1.0)))
+  expect_false(ambiguous_abstract(nv_scalar(1L)))
 
   # Non-ambiguous scalar (explicit dtype)
   expect_false(ambiguous_abstract(nv_scalar(1.0, dtype = "f32")))

--- a/vignettes/type-promotion.Rmd
+++ b/vignettes/type-promotion.Rmd
@@ -103,28 +103,18 @@ knitr::kable(tbl, format = "html", caption = "Promotion rules: ambiguous (row) Ã
 
 ## Creating Tensors with Different Ambiguity
 
-The `nv_scalar()` and `nv_tensor()` functions have different default behaviors regarding ambiguity:
-
-* `nv_scalar()` creates **ambiguous** tensors by default (when not specifying dtype explicitly), unless the data is `logical`.
-
-* `nv_tensor()` creates **non-ambiguous** tensors by default
+Both `nv_scalar()` and `nv_tensor()` create **non-ambiguous** tensors by default.
+You can explicitly control ambiguity using the `ambiguous` parameter:
 
 ```{r}
 s1 <- nv_scalar(1.0)
 ambiguous(s1)
 
+s2 <- nv_scalar(1.0, ambiguous = TRUE)
+ambiguous(s2)
+
 t1 <- nv_tensor(c(1.0, 2.0, 3.0))
 ambiguous(t1)
-
-s2 <- nv_scalar(1.0, dtype = "f32")
-ambiguous(s2)
-```
-
-You can explicitly control ambiguity using the `ambiguous` parameter:
-
-```{r}
-s3 <- nv_scalar(1.0, ambiguous = FALSE)
-ambiguous(s3)
 
 t2 <- nv_tensor(c(1.0, 2.0, 3.0), ambiguous = TRUE)
 ambiguous(t2)


### PR DESCRIPTION
The difference between nv_scalar and nv_tensor seemed somewhat arbitrary, so this hopefully makes it more consistent.