### PR TITLE
remove NSE support from nvl_if

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * Subsetting with `list()` (e.g. `x[list(1, 3)]`) is no longer supported.
   Use `array()` to wrap the indices instead, e.g. `x[array(c(1L, 3L))]`.
   This mirrors the input convention used everywhere else in the package.
+* Remove NSE support for `nvl_if`. It now requires passing 0-argument
+  closures as `true` and `false` arguments.
 
 ## New Features
 

--- a/R/api.R
+++ b/R/api.R
@@ -1409,16 +1409,16 @@ nv_reduce_all <- nvl_reduce_all
 #' of the two branches depending on a scalar predicate.
 #' @param pred ([`arrayish`] of boolean type, scalar)\cr
 #'   Predicate.
-#' @param true (`expression`)\cr
-#'   Expression for the true branch (non-standard evaluation).
-#' @param false (`expression`)\cr
-#'   Expression for the false branch (non-standard evaluation).
+#' @param true (`function()`)\cr
+#'   Zero-argument function for the true branch.
+#' @param false (`function()`)\cr
+#'   Zero-argument function for the false branch.
 #'   Must return outputs with the same shapes as the true branch.
 #' @return Result of the executed branch.
 #' @seealso [nvl_if()] for the underlying primitive, [nv_ifelse()] for
 #'   element-wise selection.
 #' @examplesIf pjrt::plugin_is_downloaded()
-#' jit_eval(nv_if(nv_scalar(TRUE), nv_scalar(1), nv_scalar(2)))
+#' jit_eval(nv_if(nv_scalar(TRUE), \() nv_scalar(1), \() nv_scalar(2)))
 #' @export
 nv_if <- nvl_if
 

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -1898,9 +1898,9 @@ p_if <- AnvilPrimitive("if", subgraphs = c("true_graph", "false_graph"))
 #' evaluates only the selected branch.
 #' @param pred ([`arrayish`])\cr
 #'   Scalar boolean predicate that determines which branch to execute.
-#' @param true,false (NSE)\cr
-#'   Expressions for the true and false branches. Both must return outputs
-#'   with the same structure, dtypes, and shapes.
+#' @param true,false (`function()`)\cr
+#'   Zero-argument functions for the true and false branches. Both must return
+#'   outputs with the same structure, dtypes, and shapes.
 #' @return Result of the executed branch.\cr
 #'   An output is ambiguous if it is ambiguous in both branches.
 #' @templateVar primitive_id if
@@ -1909,13 +1909,13 @@ p_if <- AnvilPrimitive("if", subgraphs = c("true_graph", "false_graph"))
 #' Lowers to [stablehlo::hlo_if()].
 #' @seealso [nv_if()], [nvl_ifelse()]
 #' @examplesIf pjrt::plugin_is_downloaded()
-#' jit_eval(nvl_if(nv_scalar(TRUE), nv_scalar(1), nv_scalar(2)))
+#' jit_eval(nvl_if(nv_scalar(TRUE), \() nv_scalar(1), \() nv_scalar(2)))
 #' @export
 nvl_if <- function(pred, true, false) {
   # delayed promise evaluation can cause the value to be added to the wrong graph descriptor
   force(pred)
-  true_expr <- rlang::enquo(true)
-  false_expr <- rlang::enquo(false)
+  force(true)
+  force(false)
 
   # Build sub-graphs for each branch (no inputs, just capture closed-over values)
   # We need to ensure that constants that are captured in both branches receive the same
@@ -1929,13 +1929,13 @@ nvl_if <- function(pred, true, false) {
   }
 
   desc_true <- local_descriptor()
-  true_graph <- trace_fn(function() rlang::eval_tidy(true_expr), list(), desc = desc_true, lit_to_array = TRUE)
+  true_graph <- trace_fn(true, list(), desc = desc_true, lit_to_array = TRUE)
   desc_false <- local_descriptor()
 
   for (const in desc_true$constants) {
     get_box_or_register_const(desc_false, const)
   }
-  false_graph <- trace_fn(function() rlang::eval_tidy(false_expr), list(), desc = desc_false, lit_to_array = TRUE)
+  false_graph <- trace_fn(false, list(), desc = desc_false, lit_to_array = TRUE)
 
   for (const in desc_false$constants) {
     get_box_or_register_const(current_desc, const)

--- a/man/nv_if.Rd
+++ b/man/nv_if.Rd
@@ -10,11 +10,11 @@ nv_if(pred, true, false)
 \item{pred}{(\code{\link{arrayish}} of boolean type, scalar)\cr
 Predicate.}
 
-\item{true}{(\code{expression})\cr
-Expression for the true branch (non-standard evaluation).}
+\item{true}{(\verb{function()})\cr
+Zero-argument function for the true branch.}
 
-\item{false}{(\code{expression})\cr
-Expression for the false branch (non-standard evaluation).
+\item{false}{(\verb{function()})\cr
+Zero-argument function for the false branch.
 Must return outputs with the same shapes as the true branch.}
 }
 \value{
@@ -27,7 +27,7 @@ of the two branches depending on a scalar predicate.
 }
 \examples{
 \dontshow{if (pjrt::plugin_is_downloaded()) withAutoprint(\{ # examplesIf}
-jit_eval(nv_if(nv_scalar(TRUE), nv_scalar(1), nv_scalar(2)))
+jit_eval(nv_if(nv_scalar(TRUE), \() nv_scalar(1), \() nv_scalar(2)))
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/man/nvl_if.Rd
+++ b/man/nvl_if.Rd
@@ -10,9 +10,9 @@ nvl_if(pred, true, false)
 \item{pred}{(\code{\link{arrayish}})\cr
 Scalar boolean predicate that determines which branch to execute.}
 
-\item{true, false}{(NSE)\cr
-Expressions for the true and false branches. Both must return outputs
-with the same structure, dtypes, and shapes.}
+\item{true, false}{(\verb{function()})\cr
+Zero-argument functions for the true and false branches. Both must return
+outputs with the same structure, dtypes, and shapes.}
 }
 \value{
 Result of the executed branch.\cr
@@ -39,7 +39,7 @@ Lowers to \code{\link[stablehlo:hlo_if]{stablehlo::hlo_if()}}.
 
 \examples{
 \dontshow{if (pjrt::plugin_is_downloaded()) withAutoprint(\{ # examplesIf}
-jit_eval(nvl_if(nv_scalar(TRUE), nv_scalar(1), nv_scalar(2)))
+jit_eval(nvl_if(nv_scalar(TRUE), \() nv_scalar(1), \() nv_scalar(2)))
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -78,7 +78,7 @@ test_that("while", {
 
 test_that("if", {
   f <- function(x) {
-    nv_if(nv_scalar(TRUE), x, x)
+    nv_if(nv_scalar(TRUE), \() x, \() x)
   }
   ain <- debug_box("f32", 1)
   expect_equal(f(ain)$aval, ain$aval)

--- a/tests/testthat/test-graph-passes.R
+++ b/tests/testthat/test-graph-passes.R
@@ -110,7 +110,7 @@ describe("inline_scalarish_constants", {
   it("can inline constant inputs to sub-graphs", {
     f <- function() {
       x <- nv_scalar(TRUE)
-      nv_if(x, nv_scalar(1), nv_scalar(2))
+      nv_if(x, \() nv_scalar(1), \() nv_scalar(2))
     }
     result <- check_inlining(
       graph_fun = f,
@@ -191,8 +191,8 @@ describe("inline_scalarish_constants", {
     f <- function(x, y) {
       nv_if(
         x,
-        nv_if(y, const_inner_true, const_inner_false),
-        nv_if(y, const_outer_true, const_outer_false)
+        \() nv_if(y, \() const_inner_true, \() const_inner_false),
+        \() nv_if(y, \() const_outer_true, \() const_outer_false)
       )
     }
 
@@ -245,7 +245,7 @@ describe("inline_scalarish_constants", {
     x <- nv_scalar(10)
     y <- nv_scalar(20)
     f <- function(pred) {
-      nv_if(pred, x, y)
+      nv_if(pred, \() x, \() y)
     }
     graph <- trace_fn(f, list(pred = nv_scalar(TRUE)))
     check_inlining(

--- a/tests/testthat/test-graph-print.R
+++ b/tests/testthat/test-graph-print.R
@@ -32,7 +32,7 @@ test_that("constants", {
 
 test_that("sub-graphs (if)", {
   f <- function(x) {
-    nv_if(x, nv_scalar(1, dtype = "f32"), nv_scalar(2, dtype = "f32"))
+    nv_if(x, \() nv_scalar(1, dtype = "f32"), \() nv_scalar(2, dtype = "f32"))
   }
   graph <- trace_fn(f, list(x = nv_scalar(TRUE)))
   expect_snapshot(graph)

--- a/tests/testthat/test-graph-to-quickr-edge-cases.R
+++ b/tests/testthat/test-graph-to-quickr-edge-cases.R
@@ -30,7 +30,7 @@ test_that("graph_to_quickr lowerers validate unsupported primitives in nested su
 
   graph <- trace_fn(
     function(p, x) {
-      nv_if(p, nv_popcnt(x), x)
+      nv_if(p, \() nv_popcnt(x), \() x)
     },
     list(
       p = nv_scalar(TRUE, dtype = "pred"),

--- a/tests/testthat/test-primitives-quickr-pjrt.R
+++ b/tests/testthat/test-primitives-quickr-pjrt.R
@@ -999,11 +999,11 @@ test_that("quickr pipeline matches PJRT: control flow (if/while)", {
   skip_if_no_quickr_or_pjrt()
 
   cf_ops <- function(p) {
-    if_s <- nv_if(p, 1L, 2L)
+    if_s <- nv_if(p, \() 1L, \() 2L)
     if_a <- nv_if(
       p,
-      nv_fill(1L, shape = c(2L, 2L), dtype = "i32"),
-      nv_fill(2L, shape = c(2L, 2L), dtype = "i32")
+      \() nv_fill(1L, shape = c(2L, 2L), dtype = "i32"),
+      \() nv_fill(2L, shape = c(2L, 2L), dtype = "i32")
     )
 
     w1 <- nv_while(

--- a/tests/testthat/test-primitives-reverse.R
+++ b/tests/testthat/test-primitives-reverse.R
@@ -237,7 +237,7 @@ test_that("p_if", {
   # TODO:
   #f <- jit(gradient(
   #  function(pred, x) {
-  #    nvl_if(pred, x * nv_scalar(1), x * nv_scalar(2))
+  #    nvl_if(pred, \() x * nv_scalar(1), \() x * nv_scalar(2))
   #  },
   #  wrt = "x"
   #))

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -278,7 +278,7 @@ describe("p_if", {
     f <- jit(function(pred, x) {
       x1 <- nv_mul(x, x)
       x2 <- nv_add(x, x)
-      nv_if(pred, x1, x2)
+      nv_if(pred, \() x1, \() x2)
     })
     expect_equal(
       f(nv_scalar(TRUE), nv_scalar(2)),
@@ -292,7 +292,7 @@ describe("p_if", {
 
   it("works in simple example", {
     # simple
-    f <- function(pred, x) nvl_if(pred, x, x * x)
+    f <- function(pred, x) nvl_if(pred, \() x, \() x * x)
     fj <- jit(f)
     expect_equal(fj(nv_scalar(TRUE), nv_scalar(2)), nv_scalar(2))
     expect_equal(fj(nv_scalar(FALSE), nv_scalar(2)), nv_scalar(4))
@@ -301,7 +301,7 @@ describe("p_if", {
     graph <- trace_fn(f, list(pred = nv_scalar(TRUE), x = nv_scalar(2)))
 
     f <- jit(function(pred, x) {
-      nvl_if(pred, list(list(x)), list(list(x * x)))
+      nvl_if(pred, \() list(list(x)), \() list(list(x * x)))
     })
     expect_equal(
       f(nv_scalar(TRUE), nv_scalar(2)),
@@ -313,7 +313,7 @@ describe("p_if", {
     )
 
     g <- jit(function(pred, x) {
-      nvl_if(pred, list(x[[1]]), list(x[[1]] * x[[1]]))
+      nvl_if(pred, \() list(x[[1]]), \() list(x[[1]] * x[[1]]))
     })
     expect_equal(
       g(nv_scalar(FALSE), list(nv_scalar(2))),
@@ -323,7 +323,7 @@ describe("p_if", {
 
   it("identical constants in both branches receive the same GraphValue", {
     x <- nv_scalar(1)
-    f <- function(y) nvl_if(y, x, x)
+    f <- function(y) nvl_if(y, \() x, \() x)
     graph <- trace_fn(f, list(y = nv_scalar(TRUE)))
     fj <- jit(f)
     expect_equal(fj(nv_scalar(TRUE)), nv_scalar(1))
@@ -331,14 +331,14 @@ describe("p_if", {
 
     g <- jit(function(pred) {
       y <- nv_scalar(2)
-      nvl_if(pred, y, y * nv_scalar(3))
+      nvl_if(pred, \() y, \() y * nv_scalar(3))
     })
     expect_equal(g(nv_scalar(TRUE)), nv_scalar(2))
     expect_equal(g(nv_scalar(FALSE)), nv_scalar(6))
   })
 
   it("works with literals as predicate", {
-    expect_equal(jit_eval(nv_if(TRUE, 1, 2)), nv_scalar(1, ambiguous = TRUE))
+    expect_equal(jit_eval(nv_if(TRUE, \() 1, \() 2)), nv_scalar(1, ambiguous = TRUE))
   })
 })
 
@@ -491,7 +491,7 @@ test_that("p_triangular_solve", {
 
 test_that("error when multiplying lists in if-statement", {
   f <- jit(function(pred, x) {
-    nvl_if(pred, x + x, x * x)
+    nvl_if(pred, \() x + x, \() x * x)
   })
   expect_error(
     f(nv_scalar(FALSE), list(nv_scalar(2))),

--- a/tests/testthat/test-promotion.R
+++ b/tests/testthat/test-promotion.R
@@ -32,7 +32,7 @@ test_that("p_convert reverse", {
 test_that("p_if propagates ambiguity", {
   f <- function(pred, x) {
     x <- x * 2L
-    nv_if(pred, x, x * x) * nv_scalar(3L, dtype = "i16")
+    nv_if(pred, \() x, \() x * x) * nv_scalar(3L, dtype = "i16")
   }
   expect_equal(
     jit(f)(nv_scalar(TRUE), nv_scalar(TRUE)),

--- a/vignettes/metropolis-hastings.Rmd
+++ b/vignettes/metropolis-hastings.Rmd
@@ -98,7 +98,7 @@ mh_step <- function(theta, rng_state, b, proposal_sd) {
   u <- rng_out[[2L]]
 
   accept <- log(u) < log_accept
-  new_theta <- nv_if(accept, proposal, theta)
+  new_theta <- nv_if(accept, \() proposal, \() theta)
   list(theta = new_theta, rng_state = rng_state)
 }
 ```


### PR DESCRIPTION
Anticipating introduction of eager mode, which will cause an issue as the jit cache key will use evaluated expressions while for tracing we use the captured constants, which would lead to issues.  