### PR TITLE
refactor: rename AnvilBackend field data_constructor -> new_data

### DIFF
--- a/R/array.R
+++ b/R/array.R
@@ -116,10 +116,10 @@ nv_array <- function(data, dtype = NULL, device = NULL, shape = NULL, ambiguous 
     if (!is.null(backend)) {
       cli_abort("{.arg backend} must not be specified when calling {.fn nv_array} inside {.fn jit}.")
     }
-    return(globals$backends[["plain"]]$data_constructor(data, dtype, shape, device, ambiguous))
+    return(globals$backends[["plain"]]$new_data(data, dtype, shape, device, ambiguous))
   }
   backend <- backend %||% default_backend()
-  globals$backends[[backend]]$data_constructor(data, dtype, shape, device, ambiguous)
+  globals$backends[[backend]]$new_data(data, dtype, shape, device, ambiguous)
 }
 
 is_anvil_array <- function(x) {

--- a/R/backend-quickr.R
+++ b/R/backend-quickr.R
@@ -128,7 +128,7 @@ compile_to_quickr <- function(f, args_flat, in_tree, unwrap = FALSE, flat = FALS
 #' @export
 AnvilBackendQuickr <- function() {
   backend <- AnvilBackend(
-    data_constructor = function(data, dtype, shape, device, ambiguous) {
+    new_data = function(data, dtype, shape, device, ambiguous) {
       if (is.null(dtype)) {
         dtype <- if (is.double(data)) FloatType(64) else default_dtype(data)
       }

--- a/R/backend-xla.R
+++ b/R/backend-xla.R
@@ -291,7 +291,7 @@ xla <- function(f, args, donate = character(), device = NULL) {
 #' @export
 AnvilBackendXla <- function() {
   backend <- AnvilBackend(
-    data_constructor = function(data, dtype, shape, device, ambiguous) {
+    new_data = function(data, dtype, shape, device, ambiguous) {
       buf <- pjrt_buffer(data, dtype = dtype, device = device, shape = shape)
       structure(
         list(data = buf, ambiguous = ambiguous, backend = "xla"),

--- a/R/backend.R
+++ b/R/backend.R
@@ -1,6 +1,6 @@
 #' Create a backend
 #'
-#' @param data_constructor (`function`)\cr Constructs an AnvilArray from R data.
+#' @param new_data (`function`)\cr Constructs an AnvilArray from R data.
 #' This should be a `structure()` with at least a `$data` field that contains the actual
 #' underlying data (`PJRTBuffer` for `"xla"` backend, `array()` for `"quickr"` backend).
 #' @param dtype (`function`)\cr Extracts the dtype from an AnvilArray.
@@ -18,7 +18,7 @@
 #' @keywords internal
 #' @export
 AnvilBackend <- function(
-  data_constructor,
+  new_data,
   dtype,
   shape,
   ambiguous,
@@ -32,7 +32,7 @@ AnvilBackend <- function(
 ) {
   structure(
     list(
-      data_constructor = data_constructor,
+      new_data = new_data,
       dtype = dtype,
       shape = shape,
       ambiguous = ambiguous,
@@ -72,7 +72,7 @@ globals$backends <- list()
 register_backend(
   "plain",
   AnvilBackend(
-    data_constructor = function(data, dtype, shape, device, ambiguous) {
+    new_data = function(data, dtype, shape, device, ambiguous) {
       if (is.null(dtype)) {
         dtype <- default_dtype(data)
       }

--- a/man/AnvilBackend.Rd
+++ b/man/AnvilBackend.Rd
@@ -5,7 +5,7 @@
 \title{Create a backend}
 \usage{
 AnvilBackend(
-  data_constructor,
+  new_data,
   dtype,
   shape,
   ambiguous,
@@ -19,7 +19,7 @@ AnvilBackend(
 )
 }
 \arguments{
-\item{data_constructor}{(\code{function})\cr Constructs an AnvilArray from R data.
+\item{new_data}{(\code{function})\cr Constructs an AnvilArray from R data.
 This should be a \code{structure()} with at least a \verb{$data} field that contains the actual
 underlying data (\code{PJRTBuffer} for \code{"xla"} backend, \code{array()} for \code{"quickr"} backend).}
 

--- a/tests/testthat/test-array.R
+++ b/tests/testthat/test-array.R
@@ -192,7 +192,7 @@ test_that("device returns quickr_device for quickr arrays", {
 })
 
 test_that("device returns PlainDeviceCpu for plain arrays", {
-  x <- globals$backends[["plain"]]$data_constructor(1, "f32", 1L, NULL, FALSE)
+  x <- globals$backends[["plain"]]$new_data(1, "f32", 1L, NULL, FALSE)
   dev <- device(x)
   expect_s3_class(dev, "PlainDeviceCpu")
 })
@@ -204,7 +204,7 @@ test_that("platform returns 'cpu' for quickr backend", {
 })
 
 test_that("platform returns 'cpu' for plain backend", {
-  x <- globals$backends[["plain"]]$data_constructor(1, "f32", 1L, NULL, FALSE)
+  x <- globals$backends[["plain"]]$new_data(1, "f32", 1L, NULL, FALSE)
   expect_equal(platform(x), "cpu")
 })
 


### PR DESCRIPTION
## Summary

Purely cosmetic rename: `AnvilBackend()`'s `data_constructor` field becomes `new_data`, aligning with its sibling hook `new_device` and reading better at the call sites (`backend\$new_data(...)`).

Updates all 3 backend implementations (`plain`, `xla`, `quickr`), both call sites in `R/array.R`, the roxygen doc, and the two direct references in `test-array.R`.

## Test plan

- [x] `devtools::test()` — 1492 passing, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)