### PR TITLE
fix: error on trailing-comma subscripts in nv_subset(_assign) (#267)

### DIFF
--- a/R/api-generics.R
+++ b/R/api-generics.R
@@ -182,6 +182,13 @@ t.AnvilArray <- t.AnvilBox
 #' @rdname nv_subset
 #' @export
 `[.AnvilBox` <- function(x, ...) {
+  # nargs() sees trailing missing args (e.g. the last `,` in x[1:5, , ])
+  # that rlang::enquos() silently drops.
+  n_args <- nargs() - 1L
+  rank <- length(shape_abstract(x))
+  if (n_args > rank) {
+    cli_abort("Too many subset specifications: got {n_args}, expected at most {rank}")
+  }
   quos <- rlang::enquos(...)
   rlang::inject(nv_subset(x, !!!quos))
 }
@@ -193,6 +200,11 @@ t.AnvilArray <- t.AnvilBox
 #' @rdname nv_subset_assign
 #' @export
 `[<-.AnvilBox` <- function(x, ..., value) {
+  n_args <- nargs() - 2L
+  rank <- length(shape_abstract(x))
+  if (n_args > rank) {
+    cli_abort("Too many subset specifications: got {n_args}, expected at most {rank}")
+  }
   quos <- rlang::enquos(...)
   rlang::inject(nv_subset_assign(x, !!!quos, value = value))
 }

--- a/tests/testthat/test-api-subset.R
+++ b/tests/testthat/test-api-subset.R
@@ -207,6 +207,41 @@ describe("nv_subset and nv_subset_assign", {
     )
   })
 
+  it("errors on too many subset specs (trailing empties)", {
+    x <- nv_array(1:10) # 1-D
+    expect_error(x[1:5, ], "Too many subset specifications")
+    expect_error(x[1:5, , ], "Too many subset specifications")
+    expect_error(x[1:5, 1:3, ], "Too many subset specifications")
+
+    y <- nv_array(matrix(1:6, nrow = 2)) # 2-D
+    expect_error(y[1, 1, ], "Too many subset specifications")
+    expect_error(y[1, 1, , ], "Too many subset specifications")
+  })
+
+  it("subset_assign errors on too many subset specs (trailing empties)", {
+    x <- nv_array(1:10) # 1-D
+    expect_error(
+      {
+        x[1:5, ] <- 0L
+      },
+      "Too many subset specifications"
+    )
+    expect_error(
+      {
+        x[1:5, , ] <- 0L
+      },
+      "Too many subset specifications"
+    )
+
+    y <- nv_array(matrix(1:6, nrow = 2)) # 2-D
+    expect_error(
+      {
+        y[1, 1, ] <- 0L
+      },
+      "Too many subset specifications"
+    )
+  })
+
   it("subset_assign broadcasts scalar rhs", {
     expect_jit_equal(
       {


### PR DESCRIPTION
## Summary

- `rlang::enquos(...)` silently drops trailing missing arguments, so `x[1:5, , ]` on a 1-D `AnvilArray` was captured as a single subscript and returned the 1-D slice instead of erroring (base R errors with \`incorrect number of dimensions\`).
- Fix: count the true number of subscripts with \`nargs()\` in \`\`\`[.AnvilBox\`\`\` / \`\`\`[<-.AnvilBox\`\`\` and abort when it exceeds the array's rank.

Fixes #267.

## Test plan

- [x] New \`it()\` blocks in \`tests/testthat/test-api-subset.R\` cover 1-D and 2-D cases for both \`x[...]\` and \`x[...] <- v\`, including the exact repro from the issue (\`x[1:5, , ]\`).
- [x] \`devtools::test()\`: \`FAIL 0 | PASS 1632\` (no regressions).
- [x] \`jarl check .\`: all checks passed.
- [x] Manual repro: \`x <- nv_array(1:10); x[1:5, , ]\` now errors with \`Too many subset specifications: got 3, expected at most 1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)