### PR TITLE
test: add skip_if_quickr() helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Each rule of each primitive should be tested. Tests are organized as:
 
 Prefer testing by comparing with the corresponding torch function. If the test is trivial or the functionality is not covered by torch, test manually instead. Write one or the other, not both.
 
-Tests that use the quickr backend must call `skip_if_quickr()` at the top of the test body.
+Tests that use the quickr backend must call `skip_if_no_quickr()` at the top of the test body.
 This helper skips when quickr is not installed, and also when the `ANVIL_SKIP_QUICKR` environment variable is set (quickr tests can be slow and are often skipped locally).
 To test a different backend, use `local_backend()` (not `withr::local_options()` directly).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Each rule of each primitive should be tested. Tests are organized as:
 
 Prefer testing by comparing with the corresponding torch function. If the test is trivial or the functionality is not covered by torch, test manually instead. Write one or the other, not both.
 
-Tests that use the quickr backend must call `skip_if_not_installed("quickr")` at the top of the test body.
+Tests that use the quickr backend must call `skip_if_quickr()` at the top of the test body.
+This helper skips when quickr is not installed, and also when the `ANVIL_SKIP_QUICKR` environment variable is set (quickr tests can be slow and are often skipped locally).
 To test a different backend, use `local_backend()` (not `withr::local_options()` directly).
 
 ## Documentation

--- a/tests/testthat/helper-quickr.R
+++ b/tests/testthat/helper-quickr.R
@@ -1,5 +1,12 @@
-skip_if_no_quickr_or_pjrt <- function() {
+skip_if_quickr <- function() {
   testthat::skip_if_not_installed("quickr")
+  if (nzchar(Sys.getenv("ANVIL_SKIP_QUICKR", ""))) {
+    testthat::skip("ANVIL_SKIP_QUICKR is set")
+  }
+}
+
+skip_if_no_quickr_or_pjrt <- function() {
+  skip_if_quickr()
   testthat::skip_if_not_installed("pjrt")
   testthat::skip_if_not_installed("stablehlo")
 }

--- a/tests/testthat/helper-quickr.R
+++ b/tests/testthat/helper-quickr.R
@@ -1,4 +1,4 @@
-skip_if_quickr <- function() {
+skip_if_no_quickr <- function() {
   testthat::skip_if_not_installed("quickr")
   if (nzchar(Sys.getenv("ANVIL_SKIP_QUICKR", ""))) {
     testthat::skip("ANVIL_SKIP_QUICKR is set")
@@ -6,7 +6,7 @@ skip_if_quickr <- function() {
 }
 
 skip_if_no_quickr_or_pjrt <- function() {
-  skip_if_quickr()
+  skip_if_no_quickr()
   testthat::skip_if_not_installed("pjrt")
   testthat::skip_if_not_installed("stablehlo")
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -458,7 +458,7 @@ describe("nv_triu", {
 
 describe("nv_tril with quickr backend", {
   it("works when operand is quickr", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     x <- nv_array(matrix(1, 3, 3), backend = "quickr")
     result <- nv_tril(x)
     expected <- matrix(c(1, 1, 1, 0, 1, 1, 0, 0, 1), nrow = 3, ncol = 3)
@@ -468,7 +468,7 @@ describe("nv_tril with quickr backend", {
 
 describe("nv_triu with quickr backend", {
   it("works when operand is quickr", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     x <- nv_array(matrix(1, 3, 3), backend = "quickr")
     result <- nv_triu(x)
     expected <- matrix(c(1, 0, 0, 1, 1, 0, 1, 1, 1), nrow = 3, ncol = 3)

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -458,7 +458,7 @@ describe("nv_triu", {
 
 describe("nv_tril with quickr backend", {
   it("works when operand is quickr", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     x <- nv_array(matrix(1, 3, 3), backend = "quickr")
     result <- nv_tril(x)
     expected <- matrix(c(1, 1, 1, 0, 1, 1, 0, 0, 1), nrow = 3, ncol = 3)
@@ -468,7 +468,7 @@ describe("nv_tril with quickr backend", {
 
 describe("nv_triu with quickr backend", {
   it("works when operand is quickr", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     x <- nv_array(matrix(1, 3, 3), backend = "quickr")
     result <- nv_triu(x)
     expected <- matrix(c(1, 0, 0, 1, 1, 0, 1, 1, 1), nrow = 3, ncol = 3)

--- a/tests/testthat/test-array.R
+++ b/tests/testthat/test-array.R
@@ -169,7 +169,7 @@ test_that("stablehlo dtype is printed", {
 })
 
 test_that("quickr_device is a classed object", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   dev <- quickr_device("cpu")
   expect_s3_class(dev, "QuickrDevice")
   expect_equal(format(dev), "QuickrDevice(cpu)")
@@ -184,7 +184,7 @@ test_that("PlainDeviceCpu is a classed object", {
 })
 
 test_that("device returns QuickrDevice for quickr arrays", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   x <- nv_array(1)
   dev <- device(x)
@@ -198,7 +198,7 @@ test_that("device returns PlainDeviceCpu for plain arrays", {
 })
 
 test_that("platform returns 'cpu' for quickr backend", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   expect_equal(platform(nv_array(1)), "cpu")
 })
@@ -209,14 +209,14 @@ test_that("platform returns 'cpu' for plain backend", {
 })
 
 test_that("nv_array respects backend argument", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   x <- nv_array(1, backend = "xla")
   expect_equal(backend(x), "xla")
 })
 
 test_that("nv_array infers backend from device object", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   x <- nv_array(1, device = pjrt::pjrt_device("cpu"))
   expect_equal(backend(x), "xla")
@@ -236,7 +236,7 @@ test_that("default floating dtype is f32 for xla", {
 })
 
 test_that("default floating dtype is f64 for quickr", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   expect_equal(dtype(nv_array(1.0)), as_dtype("f64"))
   expect_equal(dtype(nv_scalar(1.0)), as_dtype("f64"))
@@ -353,7 +353,7 @@ describe("as_anvil_arrays", {
   })
 
   it("errors when concrete inputs come from different backends", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     dev_xla <- nv_device("cpu", "xla")
     dev_quickr <- nv_device("cpu", "quickr")
     x <- nv_array(1:3, device = dev_xla)

--- a/tests/testthat/test-array.R
+++ b/tests/testthat/test-array.R
@@ -169,7 +169,7 @@ test_that("stablehlo dtype is printed", {
 })
 
 test_that("quickr_device is a classed object", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   dev <- quickr_device("cpu")
   expect_s3_class(dev, "QuickrDevice")
   expect_equal(format(dev), "QuickrDevice(cpu)")
@@ -184,7 +184,7 @@ test_that("PlainDeviceCpu is a classed object", {
 })
 
 test_that("device returns QuickrDevice for quickr arrays", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   x <- nv_array(1)
   dev <- device(x)
@@ -198,7 +198,7 @@ test_that("device returns PlainDeviceCpu for plain arrays", {
 })
 
 test_that("platform returns 'cpu' for quickr backend", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   expect_equal(platform(nv_array(1)), "cpu")
 })
@@ -209,14 +209,14 @@ test_that("platform returns 'cpu' for plain backend", {
 })
 
 test_that("nv_array respects backend argument", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   x <- nv_array(1, backend = "xla")
   expect_equal(backend(x), "xla")
 })
 
 test_that("nv_array infers backend from device object", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   x <- nv_array(1, device = pjrt::pjrt_device("cpu"))
   expect_equal(backend(x), "xla")
@@ -236,7 +236,7 @@ test_that("default floating dtype is f32 for xla", {
 })
 
 test_that("default floating dtype is f64 for quickr", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   expect_equal(dtype(nv_array(1.0)), as_dtype("f64"))
   expect_equal(dtype(nv_scalar(1.0)), as_dtype("f64"))
@@ -353,7 +353,7 @@ describe("as_anvil_arrays", {
   })
 
   it("errors when concrete inputs come from different backends", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     dev_xla <- nv_device("cpu", "xla")
     dev_quickr <- nv_device("cpu", "quickr")
     x <- nv_array(1:3, device = dev_xla)

--- a/tests/testthat/test-autoconvert.R
+++ b/tests/testthat/test-autoconvert.R
@@ -112,7 +112,7 @@ test_that("jit_eval: scalar expression works unchanged", {
 })
 
 test_that("quickr: autoconverts scalar input", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   f <- jit(identity)
   out <- f(1)
@@ -120,7 +120,7 @@ test_that("quickr: autoconverts scalar input", {
 })
 
 test_that("quickr: autoconverts matrix input", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   f <- jit(identity)
   out <- f(matrix(1:4, 2, 2))
@@ -130,7 +130,7 @@ test_that("quickr: autoconverts matrix input", {
 })
 
 test_that("quickr: nested input tree with mixed AnvilArray/scalar still works", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   f <- jit(function(pair) pair[[1]] + pair[[2]])
   out <- f(list(nv_scalar(1L), 2L))
@@ -138,7 +138,7 @@ test_that("quickr: nested input tree with mixed AnvilArray/scalar still works", 
 })
 
 test_that("quickr: bare vector errors", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   f <- jit(function(x) x)
   expect_snapshot(f(c(1, 2, 3)), error = TRUE)

--- a/tests/testthat/test-autoconvert.R
+++ b/tests/testthat/test-autoconvert.R
@@ -112,7 +112,7 @@ test_that("jit_eval: scalar expression works unchanged", {
 })
 
 test_that("quickr: autoconverts scalar input", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   f <- jit(identity)
   out <- f(1)
@@ -120,7 +120,7 @@ test_that("quickr: autoconverts scalar input", {
 })
 
 test_that("quickr: autoconverts matrix input", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   f <- jit(identity)
   out <- f(matrix(1:4, 2, 2))
@@ -130,7 +130,7 @@ test_that("quickr: autoconverts matrix input", {
 })
 
 test_that("quickr: nested input tree with mixed AnvilArray/scalar still works", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   f <- jit(function(pair) pair[[1]] + pair[[2]])
   out <- f(list(nv_scalar(1L), 2L))
@@ -138,7 +138,7 @@ test_that("quickr: nested input tree with mixed AnvilArray/scalar still works", 
 })
 
 test_that("quickr: bare vector errors", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   f <- jit(function(x) x)
   expect_snapshot(f(c(1, 2, 3)), error = TRUE)

--- a/tests/testthat/test-backend.R
+++ b/tests/testthat/test-backend.R
@@ -3,7 +3,7 @@ test_that("default_backend returns 'xla' by default", {
 })
 
 test_that("local_backend sets and restores the default backend", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   old <- default_backend()
   local_backend("quickr")
   expect_equal(default_backend(), "quickr")
@@ -11,7 +11,7 @@ test_that("local_backend sets and restores the default backend", {
 })
 
 test_that("with_backend temporarily changes the backend", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   expect_equal(default_backend(), "xla")
   result <- with_backend("quickr", {
     expect_equal(default_backend(), "quickr")
@@ -22,7 +22,7 @@ test_that("with_backend temporarily changes the backend", {
 })
 
 test_that("with_backend restores backend on error", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   expect_equal(default_backend(), "xla")
   try(with_backend("quickr", stop("test error")), silent = TRUE)
   expect_equal(default_backend(), "xla")
@@ -33,13 +33,13 @@ test_that("backend() returns the backend name", {
 })
 
 test_that("backend() returns 'quickr' for quickr arrays", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   expect_equal(backend(nv_array(1)), "quickr")
 })
 
 test_that("nv_empty works with quickr backend", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   x <- nv_empty("f64", c(0L, 3L))
   expect_equal(backend(x), "quickr")

--- a/tests/testthat/test-backend.R
+++ b/tests/testthat/test-backend.R
@@ -3,7 +3,7 @@ test_that("default_backend returns 'xla' by default", {
 })
 
 test_that("local_backend sets and restores the default backend", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   old <- default_backend()
   local_backend("quickr")
   expect_equal(default_backend(), "quickr")
@@ -11,7 +11,7 @@ test_that("local_backend sets and restores the default backend", {
 })
 
 test_that("with_backend temporarily changes the backend", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   expect_equal(default_backend(), "xla")
   result <- with_backend("quickr", {
     expect_equal(default_backend(), "quickr")
@@ -22,7 +22,7 @@ test_that("with_backend temporarily changes the backend", {
 })
 
 test_that("with_backend restores backend on error", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   expect_equal(default_backend(), "xla")
   try(with_backend("quickr", stop("test error")), silent = TRUE)
   expect_equal(default_backend(), "xla")
@@ -33,13 +33,13 @@ test_that("backend() returns the backend name", {
 })
 
 test_that("backend() returns 'quickr' for quickr arrays", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   expect_equal(backend(nv_array(1)), "quickr")
 })
 
 test_that("nv_empty works with quickr backend", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   x <- nv_empty("f64", c(0L, 3L))
   expect_equal(backend(x), "quickr")

--- a/tests/testthat/test-device.R
+++ b/tests/testthat/test-device.R
@@ -1,5 +1,5 @@
 test_that("nv_device dispatches to the backend-specific constructor", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   dev <- nv_device("cpu", backend = "quickr")
   expect_s3_class(dev, "QuickrDevice")
   expect_equal(backend(dev), "quickr")
@@ -17,7 +17,7 @@ test_that("nv_device errors on the plain backend", {
 })
 
 test_that("nv_device errors when pass-through device has mismatched backend", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   skip_if(!pjrt::plugins_downloaded())
   dev <- nv_device("cpu", backend = "quickr")
   expect_error(
@@ -27,14 +27,14 @@ test_that("nv_device errors when pass-through device has mismatched backend", {
 })
 
 test_that("nv_device returns an existing device unchanged", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   dev <- nv_device("cpu", backend = "quickr")
   expect_identical(nv_device(dev), dev)
   expect_identical(nv_device(dev, backend = "quickr"), dev)
 })
 
 test_that("default_device(backend = ...) uses the specified backend", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   expect_s3_class(default_device(backend = "quickr"), "QuickrDevice")
   skip_if(!pjrt::plugins_downloaded())
   expect_s3_class(default_device(backend = "xla"), "PJRTDevice")
@@ -44,7 +44,7 @@ test_that("is_device recognizes backend device objects", {
   expect_false(is_device("cpu"))
   expect_false(is_device(NULL))
   expect_false(is_device(1L))
-  skip_if_quickr()
+  skip_if_no_quickr()
   expect_true(is_device(nv_device("cpu", backend = "quickr")))
   skip_if(!pjrt::plugins_downloaded())
   expect_true(is_device(nv_device("cpu", backend = "xla")))

--- a/tests/testthat/test-device.R
+++ b/tests/testthat/test-device.R
@@ -1,5 +1,5 @@
 test_that("nv_device dispatches to the backend-specific constructor", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   dev <- nv_device("cpu", backend = "quickr")
   expect_s3_class(dev, "QuickrDevice")
   expect_equal(backend(dev), "quickr")
@@ -17,7 +17,7 @@ test_that("nv_device errors on the plain backend", {
 })
 
 test_that("nv_device errors when pass-through device has mismatched backend", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   skip_if(!pjrt::plugins_downloaded())
   dev <- nv_device("cpu", backend = "quickr")
   expect_error(
@@ -27,14 +27,14 @@ test_that("nv_device errors when pass-through device has mismatched backend", {
 })
 
 test_that("nv_device returns an existing device unchanged", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   dev <- nv_device("cpu", backend = "quickr")
   expect_identical(nv_device(dev), dev)
   expect_identical(nv_device(dev, backend = "quickr"), dev)
 })
 
 test_that("default_device(backend = ...) uses the specified backend", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   expect_s3_class(default_device(backend = "quickr"), "QuickrDevice")
   skip_if(!pjrt::plugins_downloaded())
   expect_s3_class(default_device(backend = "xla"), "PJRTDevice")
@@ -44,7 +44,7 @@ test_that("is_device recognizes backend device objects", {
   expect_false(is_device("cpu"))
   expect_false(is_device(NULL))
   expect_false(is_device(1L))
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   expect_true(is_device(nv_device("cpu", backend = "quickr")))
   skip_if(!pjrt::plugins_downloaded())
   expect_true(is_device(nv_device("cpu", backend = "xla")))

--- a/tests/testthat/test-graph-to-quickr-edge-cases.R
+++ b/tests/testthat/test-graph-to-quickr-edge-cases.R
@@ -4,7 +4,7 @@ expect_graph_to_quickr_error <- function(fn, templates, pattern) {
 }
 
 test_that("graph_to_quickr_function errors on unsupported primitives", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   unsupported_fns <- list(
     function(x) nv_popcnt(x),
@@ -26,7 +26,7 @@ test_that("graph_to_quickr_function errors on unsupported primitives", {
 })
 
 test_that("graph_to_quickr lowerers validate unsupported primitives in nested subgraphs", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   graph <- trace_fn(
     function(p, x) {
@@ -51,7 +51,7 @@ test_that("graph_to_quickr lowerers validate unsupported primitives in nested su
 })
 
 test_that("graph_to_quickr_function errors on unsupported ranks", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   # input rank > 5 is rejected during quickr argument declaration
   x6 <- array(0, dim = rep(1L, 6L))
@@ -70,14 +70,14 @@ test_that("graph_to_quickr_function errors on unsupported ranks", {
 })
 
 test_that("graph_to_quickr_function rejects unsupported dtypes", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   graph <- trace_fn(function(x) x + x, list(x = nv_aval("i64", c())))
   testthat::expect_error(graph_to_quickr_function(graph), "Unsupported dtype.*i64", fixed = FALSE)
 })
 
 test_that("graph_to_quickr_function rejects transpose ranks other than 2", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   x3 <- array(1:8, dim = c(2L, 2L, 2L))
   graph <- trace_fn(
@@ -88,7 +88,7 @@ test_that("graph_to_quickr_function rejects transpose ranks other than 2", {
 })
 
 test_that("graph_to_quickr_function rejects reshape ranks > 5", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   x5 <- array(1, dim = rep(1L, 5L))
   graph <- trace_fn(
@@ -99,7 +99,7 @@ test_that("graph_to_quickr_function rejects reshape ranks > 5", {
 })
 
 test_that("graph_to_quickr_function rejects broadcast_in_dim ranks > 5", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   graph <- trace_fn(
     function(x) nvl_broadcast_in_dim(x, shape = rep(1L, 6L), broadcast_dimensions = 6L),
@@ -109,7 +109,7 @@ test_that("graph_to_quickr_function rejects broadcast_in_dim ranks > 5", {
 })
 
 test_that("graph_to_quickr_function rejects reductions over empty dimensions", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   templ <- list(x = nv_aval("f64", c(2L, 0L)))
   graph <- trace_fn(function(x) nvl_reduce_max(x, dims = 2L, drop = TRUE), templ)
@@ -117,7 +117,7 @@ test_that("graph_to_quickr_function rejects reductions over empty dimensions", {
 })
 
 test_that("graph_to_quickr_function rejects unsupported reduce_sum variants", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   graph <- trace_fn(
     function(x) nvl_reduce_sum(x, dims = 1L, drop = TRUE),
@@ -145,7 +145,7 @@ test_that("graph_to_quickr_function rejects unsupported reduce_sum variants", {
 })
 
 test_that("throws error for unsupported dtype", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   graph <- trace_fn(
     function(x) x,

--- a/tests/testthat/test-graph-to-quickr-edge-cases.R
+++ b/tests/testthat/test-graph-to-quickr-edge-cases.R
@@ -4,7 +4,7 @@ expect_graph_to_quickr_error <- function(fn, templates, pattern) {
 }
 
 test_that("graph_to_quickr_function errors on unsupported primitives", {
-  testthat::skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   unsupported_fns <- list(
     function(x) nv_popcnt(x),
@@ -26,7 +26,7 @@ test_that("graph_to_quickr_function errors on unsupported primitives", {
 })
 
 test_that("graph_to_quickr lowerers validate unsupported primitives in nested subgraphs", {
-  testthat::skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   graph <- trace_fn(
     function(p, x) {
@@ -51,7 +51,7 @@ test_that("graph_to_quickr lowerers validate unsupported primitives in nested su
 })
 
 test_that("graph_to_quickr_function errors on unsupported ranks", {
-  testthat::skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   # input rank > 5 is rejected during quickr argument declaration
   x6 <- array(0, dim = rep(1L, 6L))
@@ -70,14 +70,14 @@ test_that("graph_to_quickr_function errors on unsupported ranks", {
 })
 
 test_that("graph_to_quickr_function rejects unsupported dtypes", {
-  testthat::skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   graph <- trace_fn(function(x) x + x, list(x = nv_aval("i64", c())))
   testthat::expect_error(graph_to_quickr_function(graph), "Unsupported dtype.*i64", fixed = FALSE)
 })
 
 test_that("graph_to_quickr_function rejects transpose ranks other than 2", {
-  testthat::skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   x3 <- array(1:8, dim = c(2L, 2L, 2L))
   graph <- trace_fn(
@@ -88,7 +88,7 @@ test_that("graph_to_quickr_function rejects transpose ranks other than 2", {
 })
 
 test_that("graph_to_quickr_function rejects reshape ranks > 5", {
-  testthat::skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   x5 <- array(1, dim = rep(1L, 5L))
   graph <- trace_fn(
@@ -99,7 +99,7 @@ test_that("graph_to_quickr_function rejects reshape ranks > 5", {
 })
 
 test_that("graph_to_quickr_function rejects broadcast_in_dim ranks > 5", {
-  testthat::skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   graph <- trace_fn(
     function(x) nvl_broadcast_in_dim(x, shape = rep(1L, 6L), broadcast_dimensions = 6L),
@@ -109,7 +109,7 @@ test_that("graph_to_quickr_function rejects broadcast_in_dim ranks > 5", {
 })
 
 test_that("graph_to_quickr_function rejects reductions over empty dimensions", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   templ <- list(x = nv_aval("f64", c(2L, 0L)))
   graph <- trace_fn(function(x) nvl_reduce_max(x, dims = 2L, drop = TRUE), templ)
@@ -117,7 +117,7 @@ test_that("graph_to_quickr_function rejects reductions over empty dimensions", {
 })
 
 test_that("graph_to_quickr_function rejects unsupported reduce_sum variants", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   graph <- trace_fn(
     function(x) nvl_reduce_sum(x, dims = 1L, drop = TRUE),
@@ -145,7 +145,7 @@ test_that("graph_to_quickr_function rejects unsupported reduce_sum variants", {
 })
 
 test_that("throws error for unsupported dtype", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   graph <- trace_fn(
     function(x) x,

--- a/tests/testthat/test-graph-to-quickr.R
+++ b/tests/testthat/test-graph-to-quickr.R
@@ -150,7 +150,7 @@ test_that("graph_to_quickr_function accepts flat static args (no nested inputs)"
 })
 
 test_that("graph_to_quickr wrappers reject mismatched runtime static args", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   flat_graph <- trace_fn(
     function(x, flag) {
@@ -224,7 +224,7 @@ test_that("graph_to_quickr_function generates placeholder names for unnamed `...
 })
 
 test_that("graph_to_quickr_function errors on mismatched flattened input structure", {
-  skip_if_quickr()
+  skip_if_no_quickr()
 
   graph <- trace_fn(
     function(x, flag) {

--- a/tests/testthat/test-graph-to-quickr.R
+++ b/tests/testthat/test-graph-to-quickr.R
@@ -150,7 +150,7 @@ test_that("graph_to_quickr_function accepts flat static args (no nested inputs)"
 })
 
 test_that("graph_to_quickr wrappers reject mismatched runtime static args", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   flat_graph <- trace_fn(
     function(x, flag) {
@@ -224,7 +224,7 @@ test_that("graph_to_quickr_function generates placeholder names for unnamed `...
 })
 
 test_that("graph_to_quickr_function errors on mismatched flattened input structure", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
 
   graph <- trace_fn(
     function(x, flag) {

--- a/tests/testthat/test-jit-quickr.R
+++ b/tests/testthat/test-jit-quickr.R
@@ -1,5 +1,5 @@
 test_that("jit: quickr backend compiles simple function", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
 
   f <- jit(function(x, y) x + y)
@@ -8,7 +8,7 @@ test_that("jit: quickr backend compiles simple function", {
 })
 
 test_that("jit: quickr backend returns AnvilArray", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
 
   f <- jit(function(x, y) x + y)
@@ -22,7 +22,7 @@ test_that("jit: quickr backend returns AnvilArray", {
 })
 
 test_that("jit: quickr backend preserves nested multi-output shapes and types", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
 
   f <- jit(
@@ -45,7 +45,7 @@ test_that("jit: quickr backend preserves nested multi-output shapes and types", 
 })
 
 test_that("jit: quickr backend does not support donate", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
   expect_error(
     jit(function(x) x, donate = "x"),
@@ -55,7 +55,7 @@ test_that("jit: quickr backend does not support donate", {
 })
 
 test_that("jit: quickr backend supports unwrap = TRUE", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
 
   f <- jit(function(x, y) x + y, unwrap = TRUE)
@@ -68,7 +68,7 @@ test_that("jit: quickr backend supports unwrap = TRUE", {
 })
 
 test_that("jit: quickr backend unwrap = TRUE preserves nested output structure", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
 
   f <- jit(
@@ -100,7 +100,7 @@ test_that("jit: quickr backend traces floating literals as f32", {
 })
 
 test_that("graph_to_quickr_r_function lowers a graph to a plain R function", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   local_backend("quickr")
 
   graph <- trace_fn(

--- a/tests/testthat/test-jit-quickr.R
+++ b/tests/testthat/test-jit-quickr.R
@@ -1,5 +1,5 @@
 test_that("jit: quickr backend compiles simple function", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
 
   f <- jit(function(x, y) x + y)
@@ -8,7 +8,7 @@ test_that("jit: quickr backend compiles simple function", {
 })
 
 test_that("jit: quickr backend returns AnvilArray", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
 
   f <- jit(function(x, y) x + y)
@@ -22,7 +22,7 @@ test_that("jit: quickr backend returns AnvilArray", {
 })
 
 test_that("jit: quickr backend preserves nested multi-output shapes and types", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
 
   f <- jit(
@@ -45,7 +45,7 @@ test_that("jit: quickr backend preserves nested multi-output shapes and types", 
 })
 
 test_that("jit: quickr backend does not support donate", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
   expect_error(
     jit(function(x) x, donate = "x"),
@@ -55,7 +55,7 @@ test_that("jit: quickr backend does not support donate", {
 })
 
 test_that("jit: quickr backend supports unwrap = TRUE", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
 
   f <- jit(function(x, y) x + y, unwrap = TRUE)
@@ -68,7 +68,7 @@ test_that("jit: quickr backend supports unwrap = TRUE", {
 })
 
 test_that("jit: quickr backend unwrap = TRUE preserves nested output structure", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
 
   f <- jit(
@@ -100,7 +100,7 @@ test_that("jit: quickr backend traces floating literals as f32", {
 })
 
 test_that("graph_to_quickr_r_function lowers a graph to a plain R function", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   local_backend("quickr")
 
   graph <- trace_fn(

--- a/tests/testthat/test-jit.R
+++ b/tests/testthat/test-jit.R
@@ -282,7 +282,7 @@ describe("jit: device and backend handling", {
   })
 
   it("backend = NULL, device = NULL follows default_backend() = 'quickr'", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     local_backend("quickr")
     f <- jit(identity)
     expect_equal(backend(f), "quickr")
@@ -309,7 +309,7 @@ describe("jit: device and backend handling", {
   })
 
   it("concrete device infers backend from device", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     local_backend("quickr")
     f <- jit(identity, device = pjrt::pjrt_device("cpu"))
     expect_equal(backend(f), "xla")
@@ -317,7 +317,7 @@ describe("jit: device and backend handling", {
   })
 
   it("concrete device conflicts with mismatched backend", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     expect_error(
       jit(identity, backend = "quickr", device = pjrt::pjrt_device("cpu")),
       "Backend of requested device"
@@ -335,12 +335,12 @@ describe("jit: device and backend handling", {
     expect_equal(backend(f), "auto")
     # At call time, backend is picked from the input.
     expect_equal(backend(f(nv_scalar(1, backend = "xla"))), "xla")
-    skip_if_quickr()
+    skip_if_no_quickr()
     expect_equal(backend(f(nv_scalar(1, backend = "quickr"))), "quickr")
   })
 
   it("backend 'auto' routes to quickr when all inputs are quickr", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     f <- jit(nv_add, backend = "auto")
     out <- f(nv_scalar(1, backend = "quickr"), nv_scalar(2, backend = "quickr"))
     expect_equal(backend(out), "quickr")
@@ -348,7 +348,7 @@ describe("jit: device and backend handling", {
   })
 
   it("backend 'auto' errs when call-time inputs use multiple backends", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     f <- jit(nv_add, backend = "auto")
     expect_error(
       f(nv_scalar(1, backend = "xla"), nv_scalar(2, backend = "quickr")),
@@ -359,7 +359,7 @@ describe("jit: device and backend handling", {
   it("cannot mix backends via closed-over constant", {
     # A closed-over constant from a different backend than the call-time input
     # must not silently compile on either backend.
-    skip_if_quickr()
+    skip_if_no_quickr()
     const_q <- nv_scalar(1, backend = "quickr")
     f <- jit(function(x) x + const_q, backend = "xla")
     expect_error(
@@ -375,14 +375,14 @@ describe("jit: device and backend handling", {
   })
 
   it("character device with backend = 'auto' is honored per chosen backend", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     f <- jit(identity, device = "cpu", backend = "auto")
     expect_equal(device(f(nv_scalar(1, backend = "xla"))), nv_device("cpu", "xla"))
     expect_equal(device(f(nv_scalar(1, backend = "quickr"))), nv_device("cpu", "quickr"))
   })
 
   it("concrete device with backend = 'auto' collapses to the device's backend", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     expect_error(
       jit(identity, device = nv_device("cpu", "quickr"), backend = "auto"),
       "Don't provide"
@@ -390,7 +390,7 @@ describe("jit: device and backend handling", {
   })
 
   it("device_arg caches separately per device value", {
-    skip_if_quickr()
+    skip_if_no_quickr()
     f <- jit(
       function(dev) nv_scalar(1, device = dev),
       backend = "auto",
@@ -489,7 +489,7 @@ describe("jit: device and backend handling", {
     g <- jit(f, device = device_arg("x"), backend = "auto")
     expect_equal(device(g("cpu:0")), nv_device("cpu:0", "xla"))
     expect_equal(device(g("cpu:1")), nv_device("cpu:1", "xla"))
-    skip_if_quickr()
+    skip_if_no_quickr()
     expect_equal(device(g(nv_device("cpu", "quickr"))), nv_device("cpu", "quickr"))
   })
 
@@ -512,7 +512,7 @@ describe("jit: device and backend handling", {
     )
     dev0 <- nv_device("cpu", "xla")
     expect_true(device(f(1, dev0)) == dev0)
-    skip_if_quickr()
+    skip_if_no_quickr()
     dev1 <- nv_device("cpu", "quickr")
     expect_true(device(f(1, dev1)) == dev1)
   })

--- a/tests/testthat/test-jit.R
+++ b/tests/testthat/test-jit.R
@@ -282,7 +282,7 @@ describe("jit: device and backend handling", {
   })
 
   it("backend = NULL, device = NULL follows default_backend() = 'quickr'", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     local_backend("quickr")
     f <- jit(identity)
     expect_equal(backend(f), "quickr")
@@ -309,7 +309,7 @@ describe("jit: device and backend handling", {
   })
 
   it("concrete device infers backend from device", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     local_backend("quickr")
     f <- jit(identity, device = pjrt::pjrt_device("cpu"))
     expect_equal(backend(f), "xla")
@@ -317,7 +317,7 @@ describe("jit: device and backend handling", {
   })
 
   it("concrete device conflicts with mismatched backend", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     expect_error(
       jit(identity, backend = "quickr", device = pjrt::pjrt_device("cpu")),
       "Backend of requested device"
@@ -335,12 +335,12 @@ describe("jit: device and backend handling", {
     expect_equal(backend(f), "auto")
     # At call time, backend is picked from the input.
     expect_equal(backend(f(nv_scalar(1, backend = "xla"))), "xla")
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     expect_equal(backend(f(nv_scalar(1, backend = "quickr"))), "quickr")
   })
 
   it("backend 'auto' routes to quickr when all inputs are quickr", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     f <- jit(nv_add, backend = "auto")
     out <- f(nv_scalar(1, backend = "quickr"), nv_scalar(2, backend = "quickr"))
     expect_equal(backend(out), "quickr")
@@ -348,7 +348,7 @@ describe("jit: device and backend handling", {
   })
 
   it("backend 'auto' errs when call-time inputs use multiple backends", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     f <- jit(nv_add, backend = "auto")
     expect_error(
       f(nv_scalar(1, backend = "xla"), nv_scalar(2, backend = "quickr")),
@@ -359,7 +359,7 @@ describe("jit: device and backend handling", {
   it("cannot mix backends via closed-over constant", {
     # A closed-over constant from a different backend than the call-time input
     # must not silently compile on either backend.
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     const_q <- nv_scalar(1, backend = "quickr")
     f <- jit(function(x) x + const_q, backend = "xla")
     expect_error(
@@ -375,14 +375,14 @@ describe("jit: device and backend handling", {
   })
 
   it("character device with backend = 'auto' is honored per chosen backend", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     f <- jit(identity, device = "cpu", backend = "auto")
     expect_equal(device(f(nv_scalar(1, backend = "xla"))), nv_device("cpu", "xla"))
     expect_equal(device(f(nv_scalar(1, backend = "quickr"))), nv_device("cpu", "quickr"))
   })
 
   it("concrete device with backend = 'auto' collapses to the device's backend", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     expect_error(
       jit(identity, device = nv_device("cpu", "quickr"), backend = "auto"),
       "Don't provide"
@@ -390,7 +390,7 @@ describe("jit: device and backend handling", {
   })
 
   it("device_arg caches separately per device value", {
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     f <- jit(
       function(dev) nv_scalar(1, device = dev),
       backend = "auto",
@@ -489,7 +489,7 @@ describe("jit: device and backend handling", {
     g <- jit(f, device = device_arg("x"), backend = "auto")
     expect_equal(device(g("cpu:0")), nv_device("cpu:0", "xla"))
     expect_equal(device(g("cpu:1")), nv_device("cpu:1", "xla"))
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     expect_equal(device(g(nv_device("cpu", "quickr"))), nv_device("cpu", "quickr"))
   })
 
@@ -512,7 +512,7 @@ describe("jit: device and backend handling", {
     )
     dev0 <- nv_device("cpu", "xla")
     expect_true(device(f(1, dev0)) == dev0)
-    skip_if_not_installed("quickr")
+    skip_if_quickr()
     dev1 <- nv_device("cpu", "quickr")
     expect_true(device(f(1, dev1)) == dev1)
   })

--- a/tests/testthat/test-serialize.R
+++ b/tests/testthat/test-serialize.R
@@ -19,7 +19,7 @@ test_that("nv_save and nv_read works for a single array", {
 })
 
 test_that("nv_serialize and nv_unserialize work for quickr backend", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   x <- nv_array(array(1:6, dim = c(2, 3)), dtype = "i32", backend = "quickr")
   lst <- list(x = x)
   raw_data <- nv_serialize(lst)
@@ -32,7 +32,7 @@ test_that("nv_serialize and nv_unserialize work for quickr backend", {
 })
 
 test_that("nv_save and nv_read work for quickr backend", {
-  skip_if_not_installed("quickr")
+  skip_if_quickr()
   x <- nv_array(c(1.5, 2.5, 3.5), dtype = "f64", backend = "quickr")
   lst <- list(x = x)
   tmp <- tempfile(fileext = ".safetensors")

--- a/tests/testthat/test-serialize.R
+++ b/tests/testthat/test-serialize.R
@@ -19,7 +19,7 @@ test_that("nv_save and nv_read works for a single array", {
 })
 
 test_that("nv_serialize and nv_unserialize work for quickr backend", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   x <- nv_array(array(1:6, dim = c(2, 3)), dtype = "i32", backend = "quickr")
   lst <- list(x = x)
   raw_data <- nv_serialize(lst)
@@ -32,7 +32,7 @@ test_that("nv_serialize and nv_unserialize work for quickr backend", {
 })
 
 test_that("nv_save and nv_read work for quickr backend", {
-  skip_if_quickr()
+  skip_if_no_quickr()
   x <- nv_array(c(1.5, 2.5, 3.5), dtype = "f64", backend = "quickr")
   lst <- list(x = x)
   tmp <- tempfile(fileext = ".safetensors")


### PR DESCRIPTION
Respects the ANVIL_SKIP_QUICKR environment variable so quickr tests (which can be slow) can be skipped locally without uninstalling quickr.