### PR TITLE
tighten edge-case handling for reductions and shape ops

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -1889,6 +1889,12 @@ nv_eigh <- prim_eigh
 #' @export
 nv_diag <- function(operand) {
   operand <- as_anvl_array(operand)
+  if (ndims(operand) != 1L) {
+    cli_abort(c(
+      "{.arg operand} must be a 1-D array.",
+      x = "Got shape {xlamisc::shapevec_repr(shape(operand))}."
+    ))
+  }
   n <- shape(operand)[1L]
   zeros <- nv_fill_like(operand, 0, shape = c(n, n))
   idx <- prim_reshape(nv_iota_like(operand, dim = 1L, shape = n, dtype = "i32"), shape = c(n, 1L))
@@ -2293,11 +2299,13 @@ nv_is_infinite <- function(operand) {
 #' @seealso [nv_sd()], [nv_mean()]
 #' @examplesIf pjrt::plugins_downloaded()
 #' x <- nv_array(c(1, 2, 3, 4, 5))
+#' nv_var(x)             # all dims -> scalar
 #' nv_var(x, dims = 1L)
 #' @export
-nv_var <- function(operand, dims, drop = TRUE, correction = 1L) {
+nv_var <- function(operand, dims = NULL, drop = TRUE, correction = 1L) {
   operand <- as_anvl_array(operand)
   assert_int(correction)
+  dims <- .resolve_reduce_dims(operand, dims)
   nelts <- prod(shape(operand)[dims])
   mean_bc <- nv_broadcast_to(
     nv_mean(operand, dims, drop = FALSE),
@@ -2321,10 +2329,10 @@ nv_var <- function(operand, dims, drop = TRUE, correction = 1L) {
 #' @seealso [nv_var()], [nv_mean()]
 #' @examplesIf pjrt::plugins_downloaded()
 #' x <- nv_array(c(1, 2, 3, 4, 5))
+#' nv_sd(x)              # all dims -> scalar
 #' nv_sd(x, dims = 1L)
 #' @export
-nv_sd <- function(operand, dims, drop = TRUE, correction = 1L) {
-  operand <- as_anvl_array(operand)
+nv_sd <- function(operand, dims = NULL, drop = TRUE, correction = 1L) {
   nv_sqrt(nv_var(operand, dims, drop, correction))
 }
 
@@ -2349,7 +2357,7 @@ nv_squeeze <- function(operand, dims = NULL) {
   if (is.null(dims)) {
     new_shape <- shp[shp != 1L]
   } else {
-    assert_integerish(dims, lower = 1L, upper = length(shp))
+    assert_integerish(dims, lower = 1L, upper = length(shp), unique = TRUE, any.missing = FALSE)
     for (d in dims) {
       if (shp[d] != 1L) {
         cli_abort("Cannot squeeze dimension {d} with size {shp[d]} (must be 1)")
@@ -2913,6 +2921,9 @@ nv_median <- function(operand, dim = NULL, interpolation = "linear") {
 #' @export
 nv_argmax <- function(operand, dim = NULL, drop = TRUE) {
   operand <- as_anvl_array(operand)
+  if (ndims(operand) == 0L) {
+    cli_abort("Cannot compute argmax of a 0-dimensional array")
+  }
   prim_argmax(operand, dim = as.integer(dim %||% ndims(operand)), drop = drop)
 }
 
@@ -2935,5 +2946,8 @@ nv_argmax <- function(operand, dim = NULL, drop = TRUE) {
 #' @export
 nv_argmin <- function(operand, dim = NULL, drop = TRUE) {
   operand <- as_anvl_array(operand)
+  if (ndims(operand) == 0L) {
+    cli_abort("Cannot compute argmin of a 0-dimensional array")
+  }
   prim_argmin(operand, dim = as.integer(dim %||% ndims(operand)), drop = drop)
 }

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -31,7 +31,25 @@ make_unary_op <- function(stablehlo_infer) {
 }
 
 
+# Named reductions (sum/prod/max/min/any/all and the API functions built on
+# top of them like mean/var/sd) refuse to reduce over a size-0 axis. For
+# max/min, the HLO lowering would silently emit the +/-Inf init sentinel; for
+# sum/prod/any/all the identity (0/1/FALSE/TRUE) is well-defined but the
+# result is rarely what users want and easy to introduce by accident. We
+# reject uniformly at trace time. `prim_reduce` (user-supplied init) is
+# intentionally exempt.
+.check_nonempty_reduce_axes <- function(operand, dims) {
+  shp <- shape(operand)
+  if (any(shp[dims] == 0L)) {
+    cli_abort(c(
+      "Cannot reduce over a zero-size axis.",
+      x = "Operand has shape {xlamisc::shapevec_repr(shp)}; reduced dims {.val {dims}} include a zero-size axis."
+    ))
+  }
+}
+
 infer_reduce <- function(operand, dims, drop) {
+  .check_nonempty_reduce_axes(operand, dims)
   old_shape <- shape(operand)
   if (drop) {
     new_shape <- old_shape[-dims]
@@ -47,6 +65,7 @@ infer_reduce <- function(operand, dims, drop) {
 }
 
 infer_reduce_boolean <- function(operand, dims, drop) {
+  .check_nonempty_reduce_axes(operand, dims)
   old_shape <- shape(operand)
   if (drop) {
     new_shape <- old_shape[-dims]

--- a/inst/extra-tests/test-primitives-stablehlo-torch.R
+++ b/inst/extra-tests/test-primitives-stablehlo-torch.R
@@ -413,6 +413,14 @@ test_that("prim_pad", {
   expect_equal(as_array(out_nv), as_array_torch(out_th))
 })
 
+test_that("prim_pad rejects non-scalar padding_value", {
+  x <- nv_array(1:6, shape = c(2, 3), dtype = "f32")
+  expect_error(
+    prim_pad(x, nv_array(c(0, 0), dtype = "f32"), c(1L, 1L), c(1L, 1L), c(0L, 0L)),
+    "must be a 0-dimensional tensor"
+  )
+})
+
 # R torch is 1-based for both dim args and returned indices, matching
 # anvl's convention. Both break ties on the smallest index, so direct
 # equality holds.

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -460,6 +460,23 @@ describe("nv_var", {
       tolerance = 1e-5
     )
   })
+  it("reduces over all axes by default", {
+    vals <- c(2, 4, 4, 4, 5, 5, 7, 9)
+    expect_equal(
+      nv_var(nv_array(vals)),
+      nv_scalar(var(vals)),
+      tolerance = 1e-5
+    )
+    expect_equal(
+      nv_var(nv_array(vals), dims = NULL),
+      nv_scalar(var(vals)),
+      tolerance = 1e-5
+    )
+  })
+  it("rejects out-of-range and duplicate dims", {
+    expect_error(nv_var(nv_array(c(1, 2, 3, 4)), dims = 5L))
+    expect_error(nv_var(nv_array(c(1, 2, 3, 4)), dims = c(1L, 1L)))
+  })
 })
 
 describe("nv_sd", {
@@ -467,6 +484,19 @@ describe("nv_sd", {
     vals <- c(2, 4, 4, 4, 5, 5, 7, 9)
     expect_equal(
       nv_sd(nv_array(vals), dims = 1L),
+      nv_scalar(sd(vals)),
+      tolerance = 1e-5
+    )
+  })
+  it("reduces over all axes by default", {
+    vals <- c(2, 4, 4, 4, 5, 5, 7, 9)
+    expect_equal(
+      nv_sd(nv_array(vals)),
+      nv_scalar(sd(vals)),
+      tolerance = 1e-5
+    )
+    expect_equal(
+      nv_sd(nv_array(vals), dims = NULL),
       nv_scalar(sd(vals)),
       tolerance = 1e-5
     )
@@ -496,6 +526,11 @@ describe("nv_squeeze", {
     expect_error(
       nv_squeeze(nv_array(1:6, shape = c(2, 3)), dims = 1L),
       "Cannot squeeze"
+    )
+  })
+  it("rejects duplicate dims", {
+    expect_error(
+      nv_squeeze(nv_array(1:6, shape = c(1, 6, 1)), dims = c(1L, 1L))
     )
   })
 })
@@ -628,6 +663,10 @@ describe("nv_diag", {
       diag(c(1, 2, 3)),
       tolerance = 1e-6
     )
+  })
+  it("rejects non-1-D inputs", {
+    expect_error(nv_diag(nv_matrix(1:6, nrow = 2)), "1-D array")
+    expect_error(nv_diag(nv_scalar(5)), "1-D array")
   })
 })
 
@@ -1080,6 +1119,10 @@ describe("nv_argmax / nv_argmin", {
     m <- nv_matrix(c(3, 1, 5, 2, 4, 0), nrow = 2, byrow = TRUE)
     expect_equal(nv_argmax(m), prim_argmax(m, dim = 2L))
     expect_equal(nv_argmin(m), prim_argmin(m, dim = 2L))
+  })
+  it("errors on a 0-dimensional input", {
+    expect_error(nv_argmax(nv_scalar(3)), "0-dimensional")
+    expect_error(nv_argmin(nv_scalar(3)), "0-dimensional")
   })
 })
 

--- a/tests/testthat/test-primitives-quickr-pjrt.R
+++ b/tests/testthat/test-primitives-quickr-pjrt.R
@@ -619,29 +619,26 @@ test_that("quickr pipeline matches PJRT: broadcast + iota slice assignments comp
   expect_quickr_matches_pjrt_fn(fn, templates, list(run))
 })
 
-test_that("quickr pipeline matches PJRT: zero-length dims (reverse/concatenate/boolean reductions)", {
+test_that("quickr pipeline matches PJRT: zero-length dims (reverse/concatenate/dynamic_slice)", {
   skip_if_no_quickr_or_pjrt()
 
   # This exercises:
   # - 0-extent *inputs* (compile-time interface)
   # - dynamic_slice with 0 slice sizes (0-extent intermediates)
-  # - reverse/concatenate/reduce_any/reduce_all on 0-extent arrays.
+  # - reverse/concatenate on 0-extent arrays.
+  # Named reductions over a zero-size axis are rejected at trace time, so
+  # they are tested separately rather than along this pipeline.
   zero_dim_ops <- function(X, empty_cols, empty_rows) {
     one <- nv_scalar(1L, dtype = "i32")
     ds_empty_cols <- prim_dynamic_slice(X, one, one, slice_sizes = c(2L, 0L))
     ds_empty_rows <- prim_dynamic_slice(X, one, one, slice_sizes = c(0L, 3L))
 
-    prim_cols <- nv_reverse(empty_cols, dims = 2L) > 0L
-
     list(
       ds_empty_cols = ds_empty_cols,
       ds_empty_rows = ds_empty_rows,
+      rev_cols = nv_reverse(empty_cols, dims = 2L),
       cat_rows = nv_concatenate(empty_rows, X, dimension = 1L),
-      cat_cols = nv_concatenate(X, empty_cols, dimension = 2L),
-      any_cols = nv_reduce_any(prim_cols, dims = 2L, drop = TRUE),
-      all_cols = nv_reduce_all(prim_cols, dims = 2L, drop = TRUE),
-      any_rows = nv_reduce_any(empty_rows > 0L, dims = 1L, drop = TRUE),
-      all_rows = nv_reduce_all(empty_rows > 0L, dims = 1L, drop = TRUE)
+      cat_cols = nv_concatenate(X, empty_cols, dimension = 2L)
     )
   }
 
@@ -662,51 +659,6 @@ test_that("quickr pipeline matches PJRT: zero-length dims (reverse/concatenate/b
 
   expect_equal(pjrt$cat_rows, X)
   expect_equal(pjrt$cat_cols, X)
-  expect_equal(as.logical(pjrt$any_cols), rep.int(FALSE, 2L))
-  expect_equal(as.logical(pjrt$all_cols), rep.int(TRUE, 2L))
-  expect_equal(as.logical(pjrt$any_rows), rep.int(FALSE, 3L))
-  expect_equal(as.logical(pjrt$all_rows), rep.int(TRUE, 3L))
-})
-
-test_that("quickr pipeline matches PJRT: zero-length dims for numeric sum/prod reductions", {
-  skip_if_no_quickr_or_pjrt()
-
-  reduce_empty_numeric <- function(v_empty, empty_cols, empty_rows) {
-    list(
-      sum_v = nv_reduce_sum(v_empty, dims = 1L, drop = TRUE),
-      prod_v_keep = nv_reduce_prod(v_empty, dims = 1L, drop = FALSE),
-      sum_cols = nv_reduce_sum(empty_cols, dims = 2L, drop = TRUE),
-      prod_cols = nv_reduce_prod(empty_cols, dims = 2L, drop = TRUE),
-      sum_rows = nv_reduce_sum(empty_rows, dims = 1L, drop = TRUE),
-      prod_rows = nv_reduce_prod(empty_rows, dims = 1L, drop = TRUE),
-      sum_full = nv_reduce_sum(empty_cols, dims = c(1L, 2L), drop = TRUE),
-      prod_full = nv_reduce_prod(empty_cols, dims = c(1L, 2L), drop = TRUE)
-    )
-  }
-
-  v_empty <- integer()
-  empty_cols <- matrix(integer(), nrow = 2L, ncol = 0L)
-  empty_rows <- matrix(integer(), nrow = 0L, ncol = 3L)
-  graph <- trace_fn(
-    reduce_empty_numeric,
-    list(
-      v_empty = nv_array(rep(0L, 0L), shape = 0L, dtype = "i32"),
-      empty_cols = nv_matrix(0L, nrow = 2L, ncol = 0L, dtype = "i32"),
-      empty_rows = nv_matrix(0L, nrow = 0L, ncol = 3L, dtype = "i32")
-    )
-  )
-
-  out_pjrt <- quickr_eval_graph_pjrt(graph, v_empty, empty_cols, empty_rows)
-  expect_identical(out_pjrt$sum_v, 0L)
-  expect_identical(out_pjrt$prod_v_keep, array(1L, dim = 1L))
-  expect_identical(out_pjrt$sum_cols, array(c(0L, 0L), dim = 2L))
-  expect_identical(out_pjrt$prod_cols, array(c(1L, 1L), dim = 2L))
-  expect_identical(out_pjrt$sum_rows, array(c(0L, 0L, 0L), dim = 3L))
-  expect_identical(out_pjrt$prod_rows, array(c(1L, 1L, 1L), dim = 3L))
-  expect_identical(out_pjrt$sum_full, 0L)
-  expect_identical(out_pjrt$prod_full, 1L)
-
-  expect_quickr_matches_pjrt(graph, v_empty, empty_cols, empty_rows)
 })
 
 test_that("quickr pipeline matches PJRT: reduction branch coverage", {

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -177,6 +177,30 @@ test_that("prim_reduce_min drop = FALSE", {
   expect_equal(out, array(c(-1, 2), c(2, 1)))
 })
 
+test_that("named reductions reject a zero-size reduction axis", {
+  empty1 <- nv_array(numeric(0), shape = 0L, dtype = "f32")
+  empty1_bool <- nv_array(logical(0), shape = 0L, dtype = "bool")
+  expect_error(prim_reduce_sum(empty1, dims = 1L, drop = TRUE), "zero-size axis")
+  expect_error(prim_reduce_prod(empty1, dims = 1L, drop = TRUE), "zero-size axis")
+  expect_error(prim_reduce_max(empty1, dims = 1L, drop = TRUE), "zero-size axis")
+  expect_error(prim_reduce_min(empty1, dims = 1L, drop = TRUE), "zero-size axis")
+  expect_error(prim_reduce_any(empty1_bool, dims = 1L, drop = TRUE), "zero-size axis")
+  expect_error(prim_reduce_all(empty1_bool, dims = 1L, drop = TRUE), "zero-size axis")
+
+  empty2 <- nv_array(numeric(0), shape = c(2L, 0L), dtype = "f32")
+  expect_error(prim_reduce_sum(empty2, dims = 2L, drop = TRUE), "zero-size axis")
+  expect_error(prim_reduce_max(empty2, dims = 2L, drop = TRUE), "zero-size axis")
+  expect_error(prim_reduce_min(empty2, dims = 2L, drop = TRUE), "zero-size axis")
+  # Reducing a non-empty axis of a tensor that has a separate empty axis is fine
+  out <- as_array(prim_reduce_max(empty2, dims = 1L, drop = TRUE))
+  expect_equal(dim(out), 0L)
+  # Also fires inside jit.
+  expect_error(
+    jit(function(x) prim_reduce_sum(x, dims = 1L, drop = TRUE))(empty1),
+    "zero-size axis"
+  )
+})
+
 test_that("prim_reduce_any", {
   x <- array(c(TRUE, FALSE, TRUE, FALSE, FALSE, FALSE), c(2, 3))
   out <- as_array(prim_reduce_any(nv_array(x, dtype = "bool"), dims = 2L, drop = TRUE))


### PR DESCRIPTION
* All named reductions (sum, prod, max, min, any, all and derivatives like mean, var, sd) reject reducing over a zero-size axis at trace time. `prim_reduce` (user-supplied init) remains exempt.
* `prim_argmax` / `prim_argmin` reject reducing over a zero-size axis; `nv_argmax` / `nv_argmin` reject 0-dimensional operands.
* `nv_diag` requires a 1-D operand.
* `nv_var` / `nv_sd` default `dims = NULL` (reduce all axes), matching the other reductions.
* `nv_squeeze` rejects duplicate dims via `assert_integerish(unique)`.