### PR TITLE
tests: add 2 missing reverse tests

### DIFF
--- a/tests/testthat/test-reverse.R
+++ b/tests/testthat/test-reverse.R
@@ -77,7 +77,17 @@ test_that("constants work (scalar)", {
 })
 
 test_that("broadcasting works", {
-  # TODO
+  # A scalar operand auto-broadcasts against a non-scalar in elementwise ops.
+  # The reverse pass must reduce the broadcasted cotangent back to the scalar's
+  # shape.
+  f <- function(a, b) sum(nv_mul(a, b))
+  g <- jit(gradient(f))
+  res <- g(nv_scalar(2), nv_array(c(1, 2, 3), dtype = "f32"))
+  # d/da sum(a * b) = sum(b) = 6, reduced back to a scalar
+  expect_equal(res$a, nv_scalar(6))
+  expect_equal(shape(res$a), integer())
+  # d/db sum(a * b) = a broadcast over b's shape
+  expect_equal(res$b, nv_array(c(2, 2, 2), dtype = "f32"))
 })
 
 test_that("second order gradient (scalar)", {
@@ -330,7 +340,10 @@ test_that("Can propagate ambiguous float32 through integer/bool functions", {
     mean(x4)
   }
   grad <- jit(gradient(f))
-  grad(nv_scalar(1))
+  out <- grad(nv_scalar(1))
+  # the path runs entirely through integer/bool conversions, so no gradient
+  # flows back to the float input.
+  expect_equal(out$x, nv_scalar(0))
 })
 
 test_that("trace_fn matches args with formals", {


### PR DESCRIPTION
Two reverse-mode gradient tests in `tests/testthat/test-reverse.R` were being silently skipped by testthat with *"Reason: empty test"* — they existed but tested nothing:

- **`:79` `"broadcasting works"`** — was just a `# TODO` stub.
- **`:324` `"Can propagate ambiguous float32 through integer/bool functions"`** — ran `grad(nv_scalar(1))` but never asserted anything.

## Changes

- **broadcasting**: asserts that a scalar operand auto-broadcasts against a vector in an elementwise op and the reverse pass reduces the broadcasted cotangent back to the scalar's shape — `d/da sum(a*b) = sum(b) = 6` (scalar) and `d/db sum(a*b) = [2,2,2]`.
- **ambiguous float32**: asserts the gradient is `0`, confirming a float can propagate through integer/bool conversions without error and no gradient flows back to the float input.

## Verification

`testthat::test_file("tests/testthat/test-reverse.R")` → `FAIL 0 | PASS 45` (was 41), with the two empty-test skips now gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)