### PR TITLE
feat: reject static arguments with reference semantics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,13 @@
 * `nv_diag()` now errors on non-1-D input instead of silently producing an
   incorrect result.
 
+* `jit()` now rejects static arguments with reference semantics -- an
+  environment (and therefore also an R6 or reference class object) or an
+  external pointer, including one nested inside a static list (#17).
+  Such a value can be mutated in place while the compilation cache key stays
+  equal, which silently reused a program compiled from its old contents.
+  Functions and device objects remain valid static values.
+
 
 # anvl 0.3.0
 

--- a/R/backend-quickr.R
+++ b/R/backend-quickr.R
@@ -36,8 +36,9 @@ print.QuickrDevice <- function(x, ...) {
 # The native-dispatch compile callback: traces and quickr-compiles on a cache
 # miss and hands the dispatcher the compiled R closure. Reached only for inputs
 # the dispatcher has already validated (see jit_xla_compile_cb).
-jit_quickr_compile_cb <- function(f, unwrap) {
+jit_quickr_compile_cb <- function(f, static, unwrap) {
   function(info) {
+    check_static_args(info$args, static)
     compiled <- compile_quickr(
       f,
       args_flat = avals_from_dispatch(info),
@@ -54,7 +55,7 @@ jit_quickr_impl <- function(f, static, cache_size, unwrap) {
   # use pjrt's "closure" engine for quickr.
   dispatcher <- pjrt::dispatcher(
     cache_size,
-    jit_quickr_compile_cb(f, unwrap),
+    jit_quickr_compile_cb(f, static, unwrap),
     static = static,
     backend = "quickr",
     # The dispatcher reads a non-xla leaf's metadata through this, via the

--- a/R/backend-xla.R
+++ b/R/backend-xla.R
@@ -3,13 +3,16 @@ NULL
 
 # Build the native-dispatch compile callback for a jitted function. Invoked by
 # pjrt's dispatcher only on a cache miss, and only for inputs the dispatcher has
-# already validated -- so this traces, lowers, and compiles, and does no
-# checking or classification of its own. `info` carries the tree, the flat
-# leaves, the static mask, and the avals the cache key was built from.
+# already validated -- so this traces, lowers, and compiles, and classifies
+# nothing itself. The one check it does make is check_static_args(): a cache
+# miss is where a static value is first used, and pjrt cannot know which values
+# anvl considers sound to key on. `info` carries the tree, the flat leaves, the
+# static mask, and the avals the cache key was built from.
 # `device` is the jit's device policy: NULL (infer), a concrete device, or a
 # device_arg() whose value is read from the static args.
-jit_xla_compile_cb <- function(f, donate, device = NULL) {
+jit_xla_compile_cb <- function(f, static, donate, device = NULL) {
   function(info) {
+    check_static_args(info$args, static)
     compile_device <- if (is_device_arg(device)) {
       info$args[[device$argname]]
     } else {
@@ -51,7 +54,7 @@ jit_xla_impl <- function(f, static, cache_size, donate, device) {
   # device is the call's device.
   dispatcher <- pjrt::dispatcher(
     cache_size,
-    jit_xla_compile_cb(f, donate, device),
+    jit_xla_compile_cb(f, static, donate, device),
     static = static,
     move_inputs = !is.null(device),
     # Consulted only when a call has no array input to name a device. It reads

--- a/R/jit.R
+++ b/R/jit.R
@@ -14,6 +14,18 @@
 #'   Names or positions of parameters of `f` that are *not* arrays. Static values are
 #'   embedded as constants in the compiled program; a new compilation is triggered whenever
 #'   a static value changes. For example useful when you want R control flow in your function.
+#'
+#'   A static value is part of the compilation cache key and later calls are compared
+#'   against it with [`identical()`], so it must not have reference semantics: an
+#'   environment (and therefore also an R6 or reference class object) or an external
+#'   pointer is rejected the first time it is traced, as is one nested inside a static
+#'   list. Such a value can be mutated in place while the cache key stays equal, which
+#'   would silently reuse a program compiled from its old contents. Pass it as a regular
+#'   argument instead, or extract the plain values you need from it.
+#'
+#'   Functions are allowed: a static function is keyed on its formals, body and
+#'   environment, and passing a callback is the point of a static argument in the first
+#'   place. Device objects are allowed too -- they are immutable, interned handles.
 #' @param cache_size (`integer(1)`)\cr
 #'   Maximum number of compiled executables to keep in the LRU cache.
 #' @param backend (`NULL` |  `character(1)`)\cr
@@ -325,6 +337,93 @@ avals_from_dispatch <- function(info) {
     list(info$leaves, info$is_static, info$avals),
     NULL
   )
+}
+
+# Reject static arguments with reference semantics, before their values are
+# traced into a program.
+#
+# A static value is part of the executable-cache key: the dispatcher keeps the
+# value and compares later calls against it with identical(). That is only
+# sound while the value's content cannot change behind its identity. An
+# environment or an external pointer can be mutated in place, leaving the key
+# equal to one whose program was compiled from different contents -- a silently
+# stale result rather than an error. So they are rejected here, at the first
+# use of the value (the cache miss that traces it).
+#
+# Called with the call's argument list, which `match.call()` has named, and the
+# jit's static argument names.
+check_static_args <- function(args, static) {
+  for (nm in intersect(rlang::names2(args), static)) {
+    check_static_value(args[[nm]], nm)
+  }
+  invisible(NULL)
+}
+
+# Walk one static value, erroring on the first reference-semantics part of it.
+# `path` is how that part is spelled from the argument, e.g. `opts$env`.
+#
+# Lists are walked because pjrt flattens a static list into one key leaf per
+# element, so an environment inside one is keyed -- and goes stale -- exactly
+# like a bare one. Attributes are not walked: they carry metadata rather than
+# values the trace reads, and a formula's `.Environment` would make every
+# static formula an error.
+check_static_value <- function(x, path) {
+  # The one reference-like static anvl passes itself (`jit(device = ...)`,
+  # `device_arg()`): a device is an immutable, interned handle, so its identity
+  # is its value.
+  if (is_device(x)) {
+    return(invisible(NULL))
+  }
+  kind <- reference_kind(x)
+  if (!is.null(kind)) {
+    cli_abort(
+      c(
+        "Static argument {.code {path}} has reference semantics: it is {kind}.",
+        x = "A static value is part of the compilation cache key and is compared by identity,
+             so mutating it in place would silently reuse a program compiled from its old contents.",
+        i = "Pass it as a regular argument, or extract the plain values you need from it."
+      ),
+      call = NULL
+    )
+  }
+  if (typeof(x) == "list") {
+    nms <- rlang::names2(x)
+    # .subset2() rather than `[[`: a classed static list must not get to decide
+    # via a method of its own what its elements are.
+    for (i in seq_along(x)) {
+      check_static_value(.subset2(x, i), static_path(path, nms[[i]], i))
+    }
+  }
+  invisible(NULL)
+}
+
+# A human description of `x`'s reference semantics, or NULL if it has none.
+# Only R's own reference types are detected: a value-semantics object that some
+# package mutates in place through C (a data.table, say) is indistinguishable
+# from a plain list here.
+reference_kind <- function(x) {
+  what <- if (is.environment(x)) {
+    "an environment"
+  } else if (typeof(x) == "externalptr") {
+    "an external pointer"
+  } else {
+    return(NULL)
+  }
+  if (is.object(x)) {
+    sprintf("an object of class <%s> (%s)", class(x)[[1L]], what)
+  } else {
+    what
+  }
+}
+
+static_path <- function(path, name, i) {
+  if (!nzchar(name)) {
+    sprintf("%s[[%i]]", path, i)
+  } else if (identical(make.names(name), name)) {
+    sprintf("%s$%s", path, name)
+  } else {
+    sprintf("%s[[\"%s\"]]", path, name)
+  }
 }
 
 # The devices of the call's array inputs, for compile_xla()'s device inference.

--- a/R/jit.R
+++ b/R/jit.R
@@ -15,17 +15,12 @@
 #'   embedded as constants in the compiled program; a new compilation is triggered whenever
 #'   a static value changes. For example useful when you want R control flow in your function.
 #'
-#'   A static value is part of the compilation cache key and later calls are compared
-#'   against it with [`identical()`], so it must not have reference semantics: an
-#'   environment (and therefore also an R6 or reference class object) or an external
-#'   pointer is rejected the first time it is traced, as is one nested inside a static
-#'   list. Such a value can be mutated in place while the cache key stays equal, which
-#'   would silently reuse a program compiled from its old contents. Pass it as a regular
-#'   argument instead, or extract the plain values you need from it.
+#'   Note that the values that are passed to static arguments must not have reference semantics.
+#'   Such a value can be mutated in place while the cache key stays equal, which
+#'   would silently reuse a program compiled from its old contents.
+#'   One exception are closures, but there you need to ensure that their
+#'   enclosing environment does not change in a way that modifies their behavior.
 #'
-#'   Functions are allowed: a static function is keyed on its formals, body and
-#'   environment, and passing a callback is the point of a static argument in the first
-#'   place. Device objects are allowed too -- they are immutable, interned handles.
 #' @param cache_size (`integer(1)`)\cr
 #'   Maximum number of compiled executables to keep in the LRU cache.
 #' @param backend (`NULL` |  `character(1)`)\cr

--- a/man/jit.Rd
+++ b/man/jit.Rd
@@ -23,17 +23,11 @@ Names or positions of parameters of \code{f} that are \emph{not} arrays. Static 
 embedded as constants in the compiled program; a new compilation is triggered whenever
 a static value changes. For example useful when you want R control flow in your function.
 
-A static value is part of the compilation cache key and later calls are compared
-against it with \code{\link[=identical]{identical()}}, so it must not have reference semantics: an
-environment (and therefore also an R6 or reference class object) or an external
-pointer is rejected the first time it is traced, as is one nested inside a static
-list. Such a value can be mutated in place while the cache key stays equal, which
-would silently reuse a program compiled from its old contents. Pass it as a regular
-argument instead, or extract the plain values you need from it.
-
-Functions are allowed: a static function is keyed on its formals, body and
-environment, and passing a callback is the point of a static argument in the first
-place. Device objects are allowed too -- they are immutable, interned handles.}
+Note that the values that are passed to static arguments must not have reference semantics.
+Such a value can be mutated in place while the cache key stays equal, which
+would silently reuse a program compiled from its old contents.
+One exception are closures, but there you need to ensure that their
+enclosing environment does not change in a way that modifies their behavior.}
 
 \item{cache_size}{(\code{integer(1)})\cr
 Maximum number of compiled executables to keep in the LRU cache.}

--- a/man/jit.Rd
+++ b/man/jit.Rd
@@ -21,7 +21,19 @@ static arguments).}
 \item{static}{(\code{character()} | \code{integer()})\cr
 Names or positions of parameters of \code{f} that are \emph{not} arrays. Static values are
 embedded as constants in the compiled program; a new compilation is triggered whenever
-a static value changes. For example useful when you want R control flow in your function.}
+a static value changes. For example useful when you want R control flow in your function.
+
+A static value is part of the compilation cache key and later calls are compared
+against it with \code{\link[=identical]{identical()}}, so it must not have reference semantics: an
+environment (and therefore also an R6 or reference class object) or an external
+pointer is rejected the first time it is traced, as is one nested inside a static
+list. Such a value can be mutated in place while the cache key stays equal, which
+would silently reuse a program compiled from its old contents. Pass it as a regular
+argument instead, or extract the plain values you need from it.
+
+Functions are allowed: a static function is keyed on its formals, body and
+environment, and passing a callback is the point of a static argument in the first
+place. Device objects are allowed too -- they are immutable, interned handles.}
 
 \item{cache_size}{(\code{integer(1)})\cr
 Maximum number of compiled executables to keep in the LRU cache.}

--- a/tests/testthat/_snaps/jit.md
+++ b/tests/testthat/_snaps/jit.md
@@ -1,0 +1,10 @@
+# rejecting a reference-semantics static names it helpfully
+
+    Code
+      f(list(a = 1, opts = list(env = e)), nv_array(1))
+    Condition
+      Error:
+      ! Static argument `s$opts$env` has reference semantics: it is an environment.
+      x A static value is part of the compilation cache key and is compared by identity, so mutating it in place would silently reuse a program compiled from its old contents.
+      i Pass it as a regular argument, or extract the plain values you need from it.
+

--- a/tests/testthat/test-jit.R
+++ b/tests/testthat/test-jit.R
@@ -549,3 +549,63 @@ test_that("cache hit when using PJRTDevice", {
   f(dev = dev1)
   expect_equal(cache_size(f), 1L)
 })
+
+test_that("static arguments with reference semantics are rejected", {
+  e <- new.env()
+  e$flag <- TRUE
+
+  f <- jit(function(e, x) if (e$flag) x else -x, static = "e")
+  expect_error(f(e, nv_array(1)), "reference semantics")
+
+  # A reference class object is an environment underneath (so is an R6 object).
+  gen <- methods::setRefClass("StaticRefCls", fields = list(flag = "logical"))
+  g <- jit(function(o, x) if (o$flag) x else -x, static = "o")
+  expect_error(g(gen$new(flag = TRUE), nv_array(1)), "reference semantics")
+
+  # External pointer.
+  h <- jit(function(p, x) x + 1, static = "p")
+  expect_error(h(pjrt::pjrt_scalar(1), nv_array(1)), "reference semantics")
+
+  # pjrt flattens a static list into one cache-key leaf per element, so an
+  # environment nested in one goes stale just like a bare one.
+  k <- jit(function(s, x) if (s$e$flag) x else -x, static = "s")
+  expect_error(k(list(e = e), nv_array(1)), "reference semantics")
+  # Also below a classed list and behind an unnamed element.
+  expect_error(k(structure(list(e = e), class = "cfg"), nv_array(1)), "reference semantics")
+  l <- jit(function(s, x) x + 1, static = "s")
+  expect_error(l(list(1, e), nv_array(1)), "reference semantics")
+})
+
+test_that("static arguments with reference semantics are rejected (quickr)", {
+  skip_if_no_quickr()
+  local_backend("quickr")
+
+  e <- new.env()
+  e$flag <- TRUE
+  f <- jit(function(e, x) if (e$flag) x else -x, static = "e")
+  expect_error(f(e, nv_array(1)), "reference semantics")
+})
+
+test_that("static arguments without reference semantics are accepted", {
+  # A function: keyed on its formals, body and environment.
+  f <- jit(function(fn, x) fn(x), static = "fn")
+  expect_equal(f(function(z) z + 1, nv_array(1)), nv_array(2))
+  expect_equal(f(function(z) z * 3, nv_array(2)), nv_array(6))
+
+  # A device is an external pointer, but an immutable interned one.
+  g <- jit(function(dev) nv_scalar(1, device = dev), static = "dev")
+  expect_equal(device(g(nv_device("cpu", "xla"))), nv_device("cpu", "xla"))
+
+  # A plain list of values, and a formula (whose `.Environment` attribute is
+  # metadata, not a value the trace reads).
+  h <- jit(function(s, x) if (s$flag) x else -x, static = "s")
+  expect_equal(h(list(flag = FALSE), nv_array(1)), nv_array(-1))
+  k <- jit(function(s, x) x + 1, static = "s")
+  expect_equal(k(y ~ x, nv_array(1)), nv_array(2))
+})
+
+test_that("rejecting a reference-semantics static names it helpfully", {
+  e <- new.env()
+  f <- jit(function(s, x) x + 1, static = "s")
+  expect_snapshot(f(list(a = 1, opts = list(env = e)), nv_array(1)), error = TRUE)
+})


### PR DESCRIPTION
A static argument's value is part of the compilation cache key: pjrt's dispatcher keeps the value and compares later calls against it with identical(). That is only sound while the value's content cannot change behind its identity. Passing an environment (or an R6/reference class object, or an external pointer) as static therefore returned silently stale results: mutating it in place left the key equal, so the executable compiled from its old contents was reused.

Reject such values at the first use of the value -- the cache miss that traces it -- naming the offending argument by its path. Static lists are walked, since pjrt flattens them into one key leaf per element.

Functions stay valid (they are keyed on formals, body and environment, and callbacks are a main reason to have static arguments), as do device objects, which are immutable interned handles.

Closes #17