### PR TITLE
fix: report arrays instead of tensors in anvl-facing errors (#298)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     pjrt (>= 0.4.0),
     rlang,
     safetensors (>= 0.2.0),
-    stablehlo (>= 0.3.0.901),
+    stablehlo (>= 0.3.0.902),
     tengen (>= 0.2.0),
     withr,
     xlamisc (>= 0.3.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,11 @@
 * `nv_diag()` now errors on non-1-D input instead of silently producing an
   incorrect result.
 
+* Errors raised while tracing now speak of arrays instead of tensors (#298).
+  Previously, messages that originated in the `stablehlo` package used the
+  StableHLO spec's terminology, e.g. `` `lhs` and `rhs` must have the same
+  tensor type. x Got tensor<4xi32> and tensor<4xf32>. ``
+
 
 # anvl 0.3.0
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -643,6 +643,8 @@ trace_fn <- function(
           if (inherits(e, "ErrorStablehlo")) {
             e <- stablehlo::to_one_based(e)
           }
+          # anvl users work with arrays, not with stableHLO tensors
+          e <- stablehlo::to_array_terminology(e)
         }
         rlang::cnd_signal(e)
       }

--- a/inst/extra-tests/test-primitives-stablehlo-torch.R
+++ b/inst/extra-tests/test-primitives-stablehlo-torch.R
@@ -417,7 +417,7 @@ test_that("prim_pad rejects non-scalar padding_value", {
   x <- nv_array(1:6, shape = c(2, 3), dtype = "f32")
   expect_error(
     prim_pad(x, nv_array(c(0, 0), dtype = "f32"), c(1L, 1L), c(1L, 1L), c(0L, 0L)),
-    "must be a 0-dimensional tensor"
+    "must be a 0-dimensional array"
   )
 })
 

--- a/tests/testthat/_snaps/graph.md
+++ b/tests/testthat/_snaps/graph.md
@@ -24,6 +24,15 @@
       ! `permutation` must be a permutation of c(1, 2).
       x Got c(2, 2).
 
+# error handling: stablehlo errors speak of arrays, not tensors
+
+    Code
+      jit(prim_add)(nv_array(1:4), nv_array(c(1, 2, 3, 4)))
+    Condition
+      Error in `prim_add()`:
+      ! `lhs` and `rhs` must have the same array type.
+      x Got array<4xi32> and array<4xf32>.
+
 # can print GraphLiteral if it holds scalar array
 
     Code

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -191,6 +191,21 @@ test_that("error handling", {
   )
 })
 
+test_that("error handling: stablehlo errors speak of arrays, not tensors", {
+  # `cli_abort()` errors from stablehlo (message lives in the condition fields)
+  expect_snapshot(error = TRUE, jit(prim_add)(nv_array(1:4), nv_array(c(1, 2, 3, 4))))
+  err <- tryCatch(jit(prim_add)(nv_array(1:4), nv_array(c(1, 2, 3, 4))), error = identity)
+  expect_false(grepl("tensor", conditionMessage(err), fixed = TRUE))
+
+  # `ErrorStablehlo` conditions (message is generated lazily) keep their class
+  # and their 1-based indices
+  err <- tryCatch(
+    jit(prim_transpose, static = "permutation")(nv_array(1:4, shape = c(2, 2)), permutation = c(2, 2)),
+    error = identity
+  )
+  expect_s3_class(err, "ErrorPermuteIndex")
+})
+
 test_that("can print GraphLiteral if it holds scalar array", {
   expect_snapshot(GraphLiteral(LiteralArray(nv_scalar(1L), dtype = "i32", shape = integer(), ambiguous = TRUE)))
 })


### PR DESCRIPTION
Errors raised by stablehlo's type inference during tracing used the StableHLO spec's "tensor" terminology. `trace_fn()` now runs them through `stablehlo::to_array_terminology()`, next to the existing `to_one_based()` conversion, so users see e.g.

  `lhs` and `rhs` must have the same array type.
  x Got array<4xi32> and array<4xf32>.