### PR TITLE
Declare xlamisc as a remote dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Suggests:
 Remotes:
     r-xla/pjrt,
     r-xla/stablehlo,
-    r-xla/tengen
+    r-xla/tengen,
+    r-xla/xlamisc
 Additional_repositories:
     https://r-xla.r-universe.dev
 VignetteBuilder:


### PR DESCRIPTION
Installing `anvl` from GitHub with pak fails while resolving `xlamisc`. DESCRIPTION identifies the r-xla R-universe through `Additional_repositories`, but pak does not use that field to extend its repository configuration. Since `xlamisc` was also absent from `Remotes`, pak could not find it in the default repositories.

Add `r-xla/xlamisc` to `Remotes`, consistent with the other r-xla development dependencies. This lets pak, and tools such as `ir` that resolve through pak, install `anvl` without a separate repository option.

This changes installation metadata only; there are no R API changes. It addresses r-lib/ir#128.

Testing: `Rscript -e 'x <- pak::pkg_deps("local::.", dependencies = NA, upgrade = TRUE); stopifnot(all(x$status == "OK"), identical(x$ref[x$package == "xlamisc"], "r-xla/xlamisc"))'`

`R -q -e 'devtools::check(args = "--no-manual", vignettes = FALSE, error_on = "error")'` completed with two errors from the existing PJRT API mismatch: examples and tests call `pjrt::dispatcher()` without its required `extractor` argument. Package build and metadata checks passed.
